### PR TITLE
✨ 로컬 회원가입 유저 플로우 및 스키마 수정

### DIFF
--- a/src/mocks/auth/handlers.ts
+++ b/src/mocks/auth/handlers.ts
@@ -6,6 +6,7 @@ export const authHandlers = [
   http.post('*/api/user/signup/send-code', authResolver.sendCode),
   http.post('*/api/user/signup/verify-email', authResolver.verfiyEmail),
   http.post('*/api/user/signup/google', authResolver.signupGoogle),
+  http.post('*/api/user/signup/local', authResolver.signUpLocal),
   http.post(
     '*/api/user/signup/id-duplicate',
     authResolver.checkLocalIdDuplicate,

--- a/src/mocks/auth/handlers.ts
+++ b/src/mocks/auth/handlers.ts
@@ -6,4 +6,8 @@ export const authHandlers = [
   http.post('*/api/user/signup/send-code', authResolver.sendCode),
   http.post('*/api/user/signup/verify-email', authResolver.verfiyEmail),
   http.post('*/api/user/signup/google', authResolver.signupGoogle),
+  http.post(
+    '*/api/user/signup/id-duplicate',
+    authResolver.checkLocalIdDuplicate,
+  ),
 ];

--- a/src/mocks/auth/resolvers.ts
+++ b/src/mocks/auth/resolvers.ts
@@ -4,6 +4,7 @@ import { mockUser } from '@/mocks/auth/data';
 import type {
   EmailVerifyRequest,
   GoogleSignUpRequest,
+  LocalIdRequest,
   SendEmailCodeRequest,
   UserWithTokenResponse,
 } from '@/mocks/auth/schemas';
@@ -16,6 +17,7 @@ type AuthResolver = {
     GoogleSignUpRequest,
     UserWithTokenResponse
   >;
+  checkLocalIdDuplicate: HttpResponseResolver<never, LocalIdRequest, never>;
 };
 
 export const authResolver: AuthResolver = {
@@ -31,5 +33,8 @@ export const authResolver: AuthResolver = {
     const { id, username, isAdmin } = mockUser;
     const body = { user: { id, username, isAdmin }, accessToken: 'asdf' };
     return HttpResponse.json(body, { status: 200 });
+  },
+  checkLocalIdDuplicate: () => {
+    return HttpResponse.json(null, { status: 200 });
   },
 };

--- a/src/mocks/auth/resolvers.ts
+++ b/src/mocks/auth/resolvers.ts
@@ -5,6 +5,7 @@ import type {
   EmailVerifyRequest,
   GoogleSignUpRequest,
   LocalIdRequest,
+  LocalSignUpRequest,
   SendEmailCodeRequest,
   UserWithTokenResponse,
 } from '@/mocks/auth/schemas';
@@ -15,6 +16,11 @@ type AuthResolver = {
   signupGoogle: HttpResponseResolver<
     never,
     GoogleSignUpRequest,
+    UserWithTokenResponse
+  >;
+  signUpLocal: HttpResponseResolver<
+    never,
+    LocalSignUpRequest,
     UserWithTokenResponse
   >;
   checkLocalIdDuplicate: HttpResponseResolver<never, LocalIdRequest, never>;
@@ -30,6 +36,11 @@ export const authResolver: AuthResolver = {
     return HttpResponse.json(null, { status: 200 });
   },
   signupGoogle: () => {
+    const { id, username, isAdmin } = mockUser;
+    const body = { user: { id, username, isAdmin }, accessToken: 'asdf' };
+    return HttpResponse.json(body, { status: 200 });
+  },
+  signUpLocal: () => {
     const { id, username, isAdmin } = mockUser;
     const body = { user: { id, username, isAdmin }, accessToken: 'asdf' };
     return HttpResponse.json(body, { status: 200 });

--- a/src/mocks/auth/schemas.ts
+++ b/src/mocks/auth/schemas.ts
@@ -29,7 +29,7 @@ export type LocalSignUpRequest = {
 
 export type LocalIdRequest = {
   localId: string;
-}
+};
 
 // Response
 export type UserWithTokenResponse = {

--- a/src/mocks/auth/schemas.ts
+++ b/src/mocks/auth/schemas.ts
@@ -27,6 +27,10 @@ export type LocalSignUpRequest = {
   snuMail: string;
 };
 
+export type LocalIdRequest = {
+  localId: string;
+}
+
 // Response
 export type UserWithTokenResponse = {
   user: UserBriefDTO;

--- a/src/mocks/auth/schemas.ts
+++ b/src/mocks/auth/schemas.ts
@@ -20,6 +20,13 @@ export type GoogleSignUpRequest = {
   googleAccesToken: string;
 };
 
+export type LocalSignUpRequest = {
+  username: string;
+  localId: string;
+  password: string;
+  snuMail: string;
+};
+
 // Response
 export type UserWithTokenResponse = {
   user: UserBriefDTO;

--- a/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
+++ b/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
@@ -22,7 +22,7 @@ export const EmailVerifyForm = () => {
   const state = location.state as EmailVerifyLocationState;
   const token = state.token;
 
-  const { email, code } = authPresentation.useValidator();
+  const { snuMail, code } = authPresentation.useValidator();
   const {
     sendCode,
     sendSuccess,
@@ -46,19 +46,19 @@ export const EmailVerifyForm = () => {
   const isPending = isPendingSend || isPendingVerify || isPendingSignup;
 
   const handleClickSendEmailCodeButton = () => {
-    if (email.isError) return;
-    sendCode({ snuMail: email.value });
+    if (snuMail.isError) return;
+    sendCode({ snuMail: snuMail.value });
   };
 
   const handleClickVerifyEmailButton = () => {
-    if (email.isError || code.isError) return;
-    emailVerify({ snuMail: email.value, code: code.value });
+    if (snuMail.isError || code.isError) return;
+    emailVerify({ snuMail: snuMail.value, code: code.value });
   };
 
   const onSubmit = () => {
-    if (email.isError || code.isError || !verifySuccess || isCodeExpired)
+    if (snuMail.isError || code.isError || !verifySuccess || isCodeExpired)
       return;
-    googleSignUp({ snuMail: email.value, token });
+    googleSignUp({ snuMail: snuMail.value, token });
   };
 
   return (
@@ -70,14 +70,14 @@ export const EmailVerifyForm = () => {
       <LabelContainer
         label="이메일"
         id="email"
-        isError={email.isError || !sendSuccess}
+        isError={snuMail.isError || !sendSuccess}
         description={codeResponseMessage}
       >
         <TextInput
           id="email"
-          value={email.value}
+          value={snuMail.value}
           onChange={(e) => {
-            email.onChange(e.target.value);
+            snuMail.onChange(e.target.value);
           }}
           disabled={isPending}
         />

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -13,7 +13,7 @@ import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
 
 export const LocalSignUpForm = () => {
   const { LocalSignUp, responseMessage, isPending } = useSignUp();
-  const { email, password, localId, phoneNumber, code } =
+  const { snuMail, password, localId, code, username } =
     authPresentation.useValidator();
 
   const [showCodeInput, setShowCodeInput] = useState(false);
@@ -24,16 +24,11 @@ export const LocalSignUpForm = () => {
   const handleClickEmailVerifyButton = () => {};
 
   const onSubmit = () => {
-    if (
-      !email.isError &&
-      !password.isError &&
-      !localId.isError &&
-      !phoneNumber.isError
-    ) {
+    if (!snuMail.isError && !password.isError && !localId.isError) {
       LocalSignUp({
-        name: localId.value,
-        email: email.value,
-        phoneNumber: phoneNumber.value,
+        localId: localId.value,
+        snuMail: snuMail.value,
+        username: username.value,
         password: password.value,
       });
     }
@@ -46,13 +41,29 @@ export const LocalSignUpForm = () => {
         response={responseMessage}
       >
         <LabelContainer
+          label="이름"
+          id="username"
+          isError={username.isError}
+          description="실명을 작성해주세요"
+        >
+          <TextInput
+            id="username"
+            value={username.value}
+            onChange={(e) => {
+              username.onChange(e.target.value);
+            }}
+            placeholder="홍길동"
+            disabled={isPending}
+          />
+        </LabelContainer>
+        <LabelContainer
           label="아이디"
-          id="name"
+          id="localId"
           isError={localId.isError}
           description="아이디는 4~20자리이며 영문 대소문자 또는 숫자 또는 -, _를 사용할 수 있습니다."
         >
           <TextInput
-            id="name"
+            id="localId"
             value={localId.value}
             onChange={(e) => {
               localId.onChange(e.target.value);
@@ -60,6 +71,7 @@ export const LocalSignUpForm = () => {
             placeholder="아이디를 입력하세요"
             disabled={isPending}
           />
+          <Button>중복확인</Button>
         </LabelContainer>
         <LabelContainer
           label="비밀번호"
@@ -98,14 +110,14 @@ export const LocalSignUpForm = () => {
         <LabelContainer
           label="이메일"
           id="email"
-          isError={email.isError}
+          isError={snuMail.isError}
           description="snu.ac.kr로 끝나는 메일을 작성해주세요."
         >
           <TextInput
             id="email"
-            value={email.value}
+            value={snuMail.value}
             onChange={(e) => {
-              email.onChange(e.target.value);
+              snuMail.onChange(e.target.value);
             }}
             placeholder="스누 메일을 입력하세요"
             disabled={isPending}
@@ -158,17 +170,17 @@ const useSignUp = () => {
 
   const { mutate: LocalSignUp, isPending } = useMutation({
     mutationFn: ({
-      name,
-      email,
-      phoneNumber,
+      username,
+      snuMail,
+      localId,
       password,
     }: {
-      name: string;
-      email: string;
+      username: string;
+      snuMail: string;
+      localId: string;
       password: string;
-      phoneNumber: string;
     }) => {
-      return authService.localSignUp({ name, email, phoneNumber, password });
+      return authService.localSignUp({ username, snuMail, localId, password });
     },
     onSuccess: (response) => {
       if (response.type === 'success') {

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -17,7 +17,7 @@ export const LocalSignUpForm = () => {
     responseMessage: responseMessageSignUp,
     isPending: isPendingSignUp,
   } = useSignUp();
-  const { snuMail, password, localId, code, username } =
+  const { snuMail, password, passwordConfirm, localId, code, username} =
     authPresentation.useValidator();
   const [showCodeInput, setShowCodeInput] = useState(false);
   const [localIdCheckSuccess, setLocalIdCheckSuccess] = useState(false);
@@ -119,18 +119,17 @@ export const LocalSignUpForm = () => {
         </LabelContainer>
         <LabelContainer
           label="비밀번호 확인"
-          id="passwordCheck"
-          isError={password.isError}
-          description="비밀번호는 8~20자리이며 영문 대소문자, 숫자, 특수문자(@#$!^*) 중 하나를 반드시 포함해야 합니다."
+          id="passwordConfirm"
+          isError={passwordConfirm.isError}
+          description="비밀번호가 일치하지 않습니다."
         >
           <TextInput
             id="passwordCheck"
             type="password"
-            value={password.value}
+            value={passwordConfirm.value}
             onChange={(e) => {
-              password.onChange(e.target.value);
+              passwordConfirm.onChange(e.target.value);
             }}
-            placeholder="비밀번호를 다시 입력해주세요"
             disabled={isPending}
           />
         </LabelContainer>

--- a/src/pages/SignUpSelectPage/GoogleSocialSignUpButton.tsx
+++ b/src/pages/SignUpSelectPage/GoogleSocialSignUpButton.tsx
@@ -12,7 +12,7 @@ export const GoogleSocialSignUpButton = () => {
   const popupGoogle = useGoogleLogin({
     onSuccess: (credentialResponse) => {
       const token = credentialResponse.access_token;
-      toVerifyEmail({ token });
+      toVerifyEmail({ token, authProvider: 'GOOGLE' });
     },
     onError: (errorResponse) => {
       setError(errorResponse.error_description);

--- a/src/presentation/authPresentation.ts
+++ b/src/presentation/authPresentation.ts
@@ -10,6 +10,7 @@ type AuthPresentation = {
   useValidator(): {
     snuMail: StringInput;
     password: StringInput;
+    passwordConfirm: StringInput;
     localId: StringInput;
     phoneNumber: StringInput;
     code: StringInput;
@@ -29,6 +30,7 @@ export const authPresentation: AuthPresentation = {
   useValidator: () => {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [passwordConfirm, setPasswordConfirm] = useState('');
     const [localId, setLocalId] = useState('');
     const [phoneNumber, setPhoneNumber] = useState('');
     const [code, setCode] = useState('');
@@ -40,6 +42,10 @@ export const authPresentation: AuthPresentation = {
 
     const handlePasswordChange = (input: string) => {
       setPassword(input);
+    };
+
+    const handlePasswordConfirmChange = (input: string) => {
+      setPasswordConfirm(input);
     };
 
     const handleLocalIdChange = (input: string) => {
@@ -68,6 +74,11 @@ export const authPresentation: AuthPresentation = {
         isError: !PASSWORD_REGEX.test(password),
         value: password,
         onChange: handlePasswordChange,
+      },
+      passwordConfirm: {
+        isError: password !== passwordConfirm,
+        value: passwordConfirm,
+        onChange: handlePasswordConfirmChange,
       },
       localId: {
         isError: !LOCAL_ID_REGEX.test(localId),

--- a/src/presentation/authPresentation.ts
+++ b/src/presentation/authPresentation.ts
@@ -8,11 +8,12 @@ type StringInput = {
 
 type AuthPresentation = {
   useValidator(): {
-    email: StringInput;
+    snuMail: StringInput;
     password: StringInput;
     localId: StringInput;
     phoneNumber: StringInput;
     code: StringInput;
+    username: StringInput;
   };
 };
 
@@ -22,6 +23,7 @@ const PASSWORD_REGEX =
 const LOCAL_ID_REGEX = /^[a-zA-Z][a-zA-Z0-9_-]{4,19}$/;
 const PHONE_NUMBER_REGEX = /^(0\d{1,2})-?\d{3,4}-?\d{4}$/;
 const CODE_REGEX = /^\d{6}$/;
+const USERNAME_REGEX = /^([가-힣]{2,6}|[A-Za-z]{2,20})$/;
 
 export const authPresentation: AuthPresentation = {
   useValidator: () => {
@@ -30,6 +32,7 @@ export const authPresentation: AuthPresentation = {
     const [localId, setLocalId] = useState('');
     const [phoneNumber, setPhoneNumber] = useState('');
     const [code, setCode] = useState('');
+    const [username, setUsername] = useState('');
 
     const handleEmailChange = (input: string) => {
       setEmail(input);
@@ -51,8 +54,12 @@ export const authPresentation: AuthPresentation = {
       setCode(input);
     };
 
+    const handleUsernameChange = (input: string) => {
+      setUsername(input);
+    };
+
     return {
-      email: {
+      snuMail: {
         isError: !EMAIL_REGEX.test(email),
         value: email,
         onChange: handleEmailChange,
@@ -76,6 +83,11 @@ export const authPresentation: AuthPresentation = {
         isError: !CODE_REGEX.test(code),
         value: code,
         onChange: handleCodeChange,
+      },
+      username: {
+        isError: !USERNAME_REGEX.test(username),
+        value: username,
+        onChange: handleUsernameChange,
       },
     };
   },

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -6,14 +6,14 @@ import type { TokenState } from '@/shared/token/state';
 
 export type AuthService = {
   localSignUp({
-    name,
-    email,
-    phoneNumber,
+    username,
+    localId,
     password,
+    snuMail,
   }: {
-    name: string;
-    email: string;
-    phoneNumber: string;
+    username: string;
+    snuMail: string;
+    localId: string;
     password: string;
   }): ServiceResponse<{
     user: Pick<User, 'id' | 'username' | 'isAdmin'>;
@@ -66,8 +66,8 @@ export const implAuthService = ({
   tokenLocalStorage: TokenLocalStorage;
   tokenState: TokenState;
 }): AuthService => ({
-  localSignUp: async ({ name, email, phoneNumber, password }) => {
-    const body = { name, email, phoneNumber, password, authProvider: 'LOCAL' };
+  localSignUp: async ({ username, localId, password, snuMail }) => {
+    const body = { username, localId, password, snuMail };
     const { status, data } = await apis['POST /user/signup/local']({ body });
 
     if (status === 200) {

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -55,6 +55,11 @@ export type AuthService = {
     snuMail: string;
     code: string;
   }): ServiceResponse<void>;
+  checkLocalIdDuplicate({
+    localId,
+  }: {
+    localId: string;
+  }): ServiceResponse<void>;
 };
 
 export const implAuthService = ({
@@ -151,6 +156,20 @@ export const implAuthService = ({
   verifyCode: async ({ code, snuMail }) => {
     const body = { snuMail, code };
     const { status, data } = await apis['POST /user/signup/verify-email']({
+      body,
+    });
+
+    if (status === 200) {
+      return {
+        type: 'success',
+        data,
+      };
+    }
+    return { type: 'error', status, message: data.error };
+  },
+  checkLocalIdDuplicate: async ({ localId }) => {
+    const body = { localId };
+    const { status, data } = await apis['POST /user/signup/id-duplicate']({
       body,
     });
 

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -5,6 +5,7 @@ import type {
   SuccessResponse,
 } from '@/shared/api/entities/params';
 import type {
+  CheckLocalIdDuplicateRequest,
   EchoParams,
   EmailVerifyRequest,
   GoogleSignInRequest,
@@ -84,6 +85,16 @@ export const getApis = ({ callWithToken, callWithoutToken }: GetApisProps) =>
       callWithoutToken<SuccessResponse<void>>({
         method: 'POST',
         path: 'user/signup/verify-email',
+        body,
+      }),
+    'POST /user/signup/id-duplicate': ({
+      body,
+    }: {
+      body: CheckLocalIdDuplicateRequest;
+    }) =>
+      callWithoutToken<SuccessResponse<void>>({
+        method: 'POST',
+        path: 'user/signup/id-duplicate',
         body,
       }),
     'GET /pretotype/mock': ({ token }: { token: string }) =>

--- a/src/shared/api/entities/schemas.ts
+++ b/src/shared/api/entities/schemas.ts
@@ -17,11 +17,10 @@ export type PretotypeUserSubmitRequest = {
 };
 
 export type LocalSignUpRequest = {
-  name: string;
-  email: string;
-  phoneNumber: string;
+  username: string;
+  localId: string;
   password: string;
-  authProvider: string;
+  snuMail: string;
 };
 
 export type LocalSignInRequest = {

--- a/src/shared/api/entities/schemas.ts
+++ b/src/shared/api/entities/schemas.ts
@@ -46,6 +46,10 @@ export type GoogleSignInRequest = {
   googleAccessToken: string;
 };
 
+export type CheckLocalIdDuplicateRequest = {
+  localId: string;
+};
+
 // Response
 export type PretotypeUserSubmitResponse = {
   email: string;

--- a/src/shared/route/useRouteNavigation.ts
+++ b/src/shared/route/useRouteNavigation.ts
@@ -2,6 +2,18 @@ import { useNavigate } from 'react-router';
 
 import { PATH } from '@/entities/route';
 
+type VerifyMailBody =
+  | {
+      authProvider: 'GOOGLE';
+      token: string;
+    }
+  | {
+      authProvider: 'LOCAL';
+      localId: string;
+      password: string;
+      username: string;
+    };
+
 export const useRouteNavigation = () => {
   const navigate = useNavigate();
   const {
@@ -26,8 +38,8 @@ export const useRouteNavigation = () => {
     toSignUpSelect: () => {
       void navigate(SIGN_UP_SELECT);
     },
-    toVerifyEmail: ({ token }: { token: string }) => {
-      void navigate(VERIFY_EMAIL, { state: { token } });
+    toVerifyEmail: (body: VerifyMailBody) => {
+      void navigate(VERIFY_EMAIL, { state: { body } });
     },
     toSignUpLocal: () => {
       void navigate(SIGN_UP_LOCAL);


### PR DESCRIPTION
### 📝 작업 내용

로컬 회원가입 시 유저 플로우를 API 및 화면 명세에 맞게 수정합니다.

### 📸 스크린샷 (선택)
- 실명, 아이디, 비밀번호, 비밀번호 확인 필드가 나타납니다.
![image](https://github.com/user-attachments/assets/5d0205fc-c07b-4e41-836d-ae9482c51ac7)

- 아이디 중복 확인을 하지 않으면 다음 단계로 넘어가지 않습니다.
![image](https://github.com/user-attachments/assets/ce45f80b-c203-4c71-becd-f764224ca6f0)

- 중복 인증 시 중복 확인 버튼이 사라집니다.
![image](https://github.com/user-attachments/assets/cbda53df-1026-4ad1-b5d8-bb63fdaddf89)

- 이후 다음을 누르면 이메일 인증 페이지로 넘어갑니다.

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
