### PR TITLE
✨ 화면 명세 중 로컬 회원가입 조건 반영

### DIFF
--- a/src/components/input/LabelContainer.tsx
+++ b/src/components/input/LabelContainer.tsx
@@ -1,25 +1,16 @@
 interface LabelContainertProps extends React.HTMLAttributes<HTMLDivElement> {
   label: string;
-  isError?: boolean;
-  description?: string;
 }
 
 export const LabelContainer = ({
   children,
   label,
   id,
-  isError,
-  description,
 }: LabelContainertProps) => {
   return (
     <div>
       <label htmlFor={id}>{label}</label>
       {children}
-      {description !== undefined && isError === true && (
-        <div style={{ marginTop: '20px', fontSize: '12px', color: 'black' }}>
-          <strong>{description}</strong>
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/input/TextInput.tsx
+++ b/src/components/input/TextInput.tsx
@@ -8,6 +8,8 @@ export const TextInput = ({
   id,
   onChange,
   onKeyDown,
+  onFocus,
+  onBlur,
   placeholder,
 }: TextInputProps) => {
   return (
@@ -17,6 +19,8 @@ export const TextInput = ({
       value={value}
       onChange={onChange}
       onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      onBlur={onBlur}
       placeholder={placeholder}
       style={{ padding: '10px', width: '300px', fontSize: '16px' }}
     />

--- a/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
+++ b/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
@@ -106,12 +106,7 @@ export const EmailVerifyForm = () => {
           : googleSignUpResponseMessage
       }
     >
-      <LabelContainer
-        label="이메일"
-        id="email"
-        isError={snuMail.isError || !sendSuccess}
-        description={codeResponseMessage}
-      >
+      <LabelContainer label="이메일" id="email">
         <TextInput
           id="email"
           value={snuMail.value}
@@ -126,15 +121,11 @@ export const EmailVerifyForm = () => {
           handleClickSendEmailCodeButton={handleClickSendEmailCodeButton}
           isPending={isPending}
         />
+        <div>{codeResponseMessage}</div>
       </LabelContainer>
       {sendSuccess && (
         <>
-          <LabelContainer
-            label="인증 코드"
-            id="code"
-            isError={code.isError || verifySuccess}
-            description={emailResponseMessage}
-          >
+          <LabelContainer label="인증 코드" id="code">
             <TextInput
               id="code"
               value={code.value}
@@ -150,6 +141,7 @@ export const EmailVerifyForm = () => {
               handleClickVerifyEmailButton={handleClickVerifyEmailButton}
               isPending={isPending}
             />
+            <div>{emailResponseMessage}</div>
           </LabelContainer>
         </>
       )}

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -95,7 +95,12 @@ export const LocalSignUpForm = () => {
               placeholder="아이디를 입력해주세요."
               disabled={isPending}
             />
-            <Button onClick={handleClickUsernameDuplicateCheck}>
+            <Button
+              onClick={(event) => {
+                event.preventDefault();
+                handleClickUsernameDuplicateCheck();
+              }}
+            >
               중복확인
             </Button>
             {localIdCheckSuccess && <div>사용할 수 있는 아이디예요.</div>}

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -103,7 +103,11 @@ export const LocalSignUpForm = () => {
             >
               중복확인
             </Button>
-            {localIdCheckSuccess && <div>사용할 수 있는 아이디예요.</div>}
+            {localIdCheckSuccess ? (
+              <div>사용할 수 있는 아이디입니다.</div>
+            ) : (
+              <div>사용할 수 없는 아이디입니다. 다시 입력해주세요.</div>
+            )}
           </LabelContainer>
           <LabelContainer label="비밀번호" id="password">
             <TextInput

--- a/src/presentation/authPresentation.ts
+++ b/src/presentation/authPresentation.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 type StringInput = {
   isError: boolean;
+  detailedError?: Record<string, boolean>;
   value: string;
   onChange: (e: string) => void;
 };
@@ -21,6 +22,12 @@ type AuthPresentation = {
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@snu\.ac\.kr$/;
 const PASSWORD_REGEX =
   /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@#$!^*])[A-Za-z\d@#$!^*]{8,20}$/;
+const PASSWORD_DETAIL_REGEX = {
+  ENGLISH_REGEX: /(?=.*[A-Z])(?=.*[a-z])/,
+  NUMBER_REGEX: /\d/,
+  SPECIAL_CHAR_REGEX: /[@#$!^*]/,
+  LENGTH_REGEX: /^.{8,20}$/,
+};
 const LOCAL_ID_REGEX = /^[a-zA-Z][a-zA-Z0-9_-]{4,19}$/;
 const PHONE_NUMBER_REGEX = /^(0\d{1,2})-?\d{3,4}-?\d{4}$/;
 const CODE_REGEX = /^\d{6}$/;
@@ -73,6 +80,13 @@ export const authPresentation: AuthPresentation = {
       password: {
         isError: !PASSWORD_REGEX.test(password),
         value: password,
+        detailedError: {
+          englishError: !PASSWORD_DETAIL_REGEX.ENGLISH_REGEX.test(password),
+          numberError: !PASSWORD_DETAIL_REGEX.NUMBER_REGEX.test(password),
+          specialCharError:
+            !PASSWORD_DETAIL_REGEX.SPECIAL_CHAR_REGEX.test(password),
+          lengthError: !PASSWORD_DETAIL_REGEX.LENGTH_REGEX.test(password),
+        },
         onChange: handlePasswordChange,
       },
       passwordConfirm: {


### PR DESCRIPTION
### 📝 작업 내용

로컬 회원가입 조건을 반영합니다.

### 📸 스크린샷 (선택)
중복확인 완료 시 성공 및 실패 문구가 나타나도록 합니다.
![image](https://github.com/user-attachments/assets/a311b258-db6d-4d09-aaf2-c9e6893c79ff)

비밀번호 클릭 시 조건이 나타날 수 있도록 합니다.
![image](https://github.com/user-attachments/assets/effe4494-744f-4180-91c2-aee1ba479407)

조건은 입력하는대로 변화하도록 합니다.
![image](https://github.com/user-attachments/assets/d391d629-8bd9-461b-9b7f-c32711705f34)

이때 비밀번호 input에서 focus를 해제하면 조건이 나타나지 않습니다.
![image](https://github.com/user-attachments/assets/22230834-e51d-4225-bf72-f5e427c19c2a)

비밀번호 확인 input에 한 개 이상의 문자가 들어가면 일치 여부를 확인하는 문구가 하단에 나타납니다.
![image](https://github.com/user-attachments/assets/f2687911-560b-4dd1-b3b0-ca2996a623e8)

회원가입하기 버튼을 눌렀을 때 에러는 하단에 나타나도록 합니다.
![image](https://github.com/user-attachments/assets/3153553f-f74c-4fc8-9f1e-5f55eb27de24)

작성 완료 시 이메일 인증 페이지로 이동합니다.
![image](https://github.com/user-attachments/assets/d018eedd-8e87-44b7-9048-96e486fd0b50)


### 🚀 리뷰 요구사항 (선택)

- 유저 플로우가 맞는지 다시 한 번 확인해주시기 바랍니다.
