### PR TITLE
✨ 이메일 인증 페이지 유저 플로우 반영

### DIFF
--- a/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
+++ b/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
@@ -33,7 +33,7 @@ export const EmailVerifyForm = () => {
   const location = useLocation();
   const state = location.state as EmailVerifyLocationState | undefined;
 
-  const { toSignUpLocal, toMain } = useRouteNavigation();
+  const { toSignUpLocal, toSignUpSelect } = useRouteNavigation();
   const [showSendCodeError, setShowSendCodeError] = useState(false);
   const { snuMail, code } = authPresentation.useValidator({});
   const {
@@ -107,7 +107,7 @@ export const EmailVerifyForm = () => {
       toSignUpLocal(body);
       return;
     }
-    toMain();
+    toSignUpSelect();
   };
 
   return (

--- a/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
+++ b/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
@@ -33,7 +33,9 @@ export const EmailVerifyForm = () => {
   const location = useLocation();
   const state = location.state as EmailVerifyLocationState | undefined;
 
-  const { snuMail, code } = authPresentation.useValidator();
+  const { toSignUpLocal, toMain } = useRouteNavigation();
+  const [showSendCodeError, setShowSendCodeError] = useState(false);
+  const { snuMail, code } = authPresentation.useValidator({});
   const {
     sendCode,
     sendSuccess,
@@ -71,7 +73,11 @@ export const EmailVerifyForm = () => {
   const { body } = state;
 
   const handleClickSendEmailCodeButton = () => {
-    if (snuMail.isError) return;
+    if (snuMail.isError) {
+      setShowSendCodeError(true);
+      return;
+    }
+
     sendCode({ snuMail: snuMail.value });
   };
 
@@ -96,6 +102,14 @@ export const EmailVerifyForm = () => {
     }
   };
 
+  const hanldeClickPreviousButton = () => {
+    if (body.authProvider === 'LOCAL') {
+      toSignUpLocal(body);
+      return;
+    }
+    toMain();
+  };
+
   return (
     <FormContainer
       id="EmailVerifyForm"
@@ -115,12 +129,14 @@ export const EmailVerifyForm = () => {
           }}
           disabled={isPending}
         />
-        <ShowSendEmailCodeButton
-          sendSuccess={sendSuccess}
-          verifySuccess={verifySuccess}
-          handleClickSendEmailCodeButton={handleClickSendEmailCodeButton}
-          isPending={isPending}
-        />
+        {!verifySuccess && (
+          <Button onClick={handleClickSendEmailCodeButton} disabled={isPending}>
+            인증코드 받기
+          </Button>
+        )}
+        {showSendCodeError && snuMail.isError && (
+          <div>유효하지 않은 스누메일입니다.</div>
+        )}
         <div>{codeResponseMessage}</div>
       </LabelContainer>
       {sendSuccess && (
@@ -145,43 +161,30 @@ export const EmailVerifyForm = () => {
           </LabelContainer>
         </>
       )}
-      <SubmitButton
-        form="EmailVerifyForm"
-        disabled={isPending}
-        onSubmit={onSubmit}
-      >
-        회원가입 완료
-      </SubmitButton>
+      <p>
+        인증코드가 오지 않았다면?{' '}
+        <a
+          onClick={handleClickSendEmailCodeButton}
+          style={{
+            textDecoration: 'underline',
+            cursor: 'pointer',
+          }}
+        >
+          재발송
+        </a>
+      </p>
+      <div>
+        <Button onClick={hanldeClickPreviousButton}>이전</Button>
+        <SubmitButton
+          form="EmailVerifyForm"
+          disabled={isPending}
+          onSubmit={onSubmit}
+        >
+          회원가입 완료
+        </SubmitButton>
+      </div>
     </FormContainer>
   );
-};
-
-const ShowSendEmailCodeButton = ({
-  sendSuccess,
-  verifySuccess,
-  handleClickSendEmailCodeButton,
-  isPending,
-}: {
-  sendSuccess: boolean;
-  verifySuccess: boolean;
-  handleClickSendEmailCodeButton(): void;
-  isPending: boolean;
-}) => {
-  if (verifySuccess) {
-    return <div>인증 성공</div>;
-  } else if (sendSuccess) {
-    return (
-      <Button onClick={handleClickSendEmailCodeButton} disabled={isPending}>
-        인증코드 재발송
-      </Button>
-    );
-  } else {
-    return (
-      <Button onClick={handleClickSendEmailCodeButton} disabled={isPending}>
-        인증코드 받기
-      </Button>
-    );
-  }
 };
 
 const ShowVerifyEmailButton = ({

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -29,7 +29,7 @@ export const LocalSignUpForm = () => {
 
   const { toVerifyEmail } = useRouteNavigation();
   const { password, passwordConfirm, localId, username } =
-    authPresentation.useValidator(state);
+    authPresentation.useValidator({ initialState: state });
   const [localIdCheckSuccess, setLocalIdCheckSuccess] = useState(false);
   const [isPasswordFocused, setIsPasswordFocused] = useState(false);
   const [isPasswordConfirmFocused, setIsPasswordConfirmFocused] =

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -29,7 +29,7 @@ export const LocalSignUpForm = () => {
 
   const { toVerifyEmail } = useRouteNavigation();
   const { password, passwordConfirm, localId, username } =
-    authPresentation.useValidator({ initialState: state });
+    authPresentation.useValidator({ initialState: state?.body });
   const [localIdCheckSuccess, setLocalIdCheckSuccess] = useState(false);
   const [isPasswordFocused, setIsPasswordFocused] = useState(false);
   const [isPasswordConfirmFocused, setIsPasswordConfirmFocused] =

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -1,5 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useLocation } from 'react-router';
 
 import { SubmitButton } from '@/components/button';
 import { Button } from '@/components/button';
@@ -11,10 +12,24 @@ import { useGuardContext } from '@/shared/context/hooks';
 import { ServiceContext } from '@/shared/context/ServiceContext';
 import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
 
+type PreviousForm = {
+  authProvider: 'LOCAL';
+  localId: string;
+  password: string;
+  username: string;
+};
+
+type LocalSignUpInitialBody = {
+  body: PreviousForm | undefined;
+};
+
 export const LocalSignUpForm = () => {
+  const location = useLocation();
+  const state = location.state as LocalSignUpInitialBody | undefined;
+
   const { toVerifyEmail } = useRouteNavigation();
   const { password, passwordConfirm, localId, username } =
-    authPresentation.useValidator();
+    authPresentation.useValidator(state);
   const [localIdCheckSuccess, setLocalIdCheckSuccess] = useState(false);
   const [isPasswordFocused, setIsPasswordFocused] = useState(false);
   const [isPasswordConfirmFocused, setIsPasswordConfirmFocused] =
@@ -25,6 +40,10 @@ export const LocalSignUpForm = () => {
     setLocalIdCheckSuccess,
     setResponseMessage,
   });
+
+  if (state === undefined) {
+    return <div>유효하지 않은 접근입니다.</div>;
+  }
 
   const handleClickUsernameDuplicateCheck = () => {
     if (localId.isError || localIdCheckSuccess) return;
@@ -103,11 +122,7 @@ export const LocalSignUpForm = () => {
             >
               중복확인
             </Button>
-            {localIdCheckSuccess ? (
-              <div>사용할 수 있는 아이디입니다.</div>
-            ) : (
-              <div>사용할 수 없는 아이디입니다. 다시 입력해주세요.</div>
-            )}
+            {localIdCheckSuccess && <div>사용할 수 있는 아이디입니다.</div>}
           </LabelContainer>
           <LabelContainer label="비밀번호" id="password">
             <TextInput
@@ -162,7 +177,6 @@ export const LocalSignUpForm = () => {
                 }
                 passwordConfirm.onChange(e.target.value);
               }}
-              onFocus={() => {}}
               placeholder="비밀번호를 한번 더 입력해주세요."
               disabled={isPending}
             />

--- a/src/pages/SignInSelectPage/LogInForm.tsx
+++ b/src/pages/SignInSelectPage/LogInForm.tsx
@@ -12,7 +12,7 @@ import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
 
 export const LocalLogInForm = () => {
   const { localSignIn, responseMessage, isPending } = useLocalSignIn();
-  const { localId, password } = authPresentation.useValidator();
+  const { localId, password } = authPresentation.useValidator({});
 
   const onSubmit = () => {
     if (!localId.isError && !password.isError) {

--- a/src/pages/SignUpSelectPage/index.tsx
+++ b/src/pages/SignUpSelectPage/index.tsx
@@ -9,7 +9,13 @@ export const SignUpSelectPage = () => {
     <div>
       <p>회원가입 페이지입니다.</p>
       <GoogleSocialSignUpButton />
-      <Button onClick={toSignUpLocal}>일반 회원가입</Button>
+      <Button
+        onClick={() => {
+          toSignUpLocal();
+        }}
+      >
+        일반 회원가입
+      </Button>
       <Button onClick={toMain}>메인으로 이동</Button>
     </div>
   );

--- a/src/presentation/authPresentation.ts
+++ b/src/presentation/authPresentation.ts
@@ -7,8 +7,18 @@ type StringInput = {
   onChange: (e: string) => void;
 };
 
+type InitialState = {
+  snuMail?: string;
+  password?: string;
+  passwordConfirm?: string;
+  localId?: string;
+  phoneNumber?: string;
+  code?: string;
+  username?: string;
+};
+
 type AuthPresentation = {
-  useValidator({ initialState }: { initialState?: { body?: PreviousForm } }): {
+  useValidator({ initialState }: { initialState?: InitialState }): {
     snuMail: StringInput;
     password: StringInput;
     passwordConfirm: StringInput;
@@ -17,13 +27,6 @@ type AuthPresentation = {
     code: StringInput;
     username: StringInput;
   };
-};
-
-type PreviousForm = {
-  authProvider: 'LOCAL';
-  localId: string;
-  password: string;
-  username: string;
 };
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@snu\.ac\.kr$/;
@@ -42,18 +45,28 @@ const USERNAME_REGEX = /^([가-힣]{2,6}|[A-Za-z]{2,20})$/;
 
 export const authPresentation: AuthPresentation = {
   useValidator: ({ initialState = {} }) => {
-    const [email, setEmail] = useState('');
+    const [email, setEmail] = useState(
+      initialState.snuMail !== undefined ? initialState.snuMail : '',
+    );
     const [password, setPassword] = useState(
-      initialState.body !== undefined ? initialState.body.password : '',
+      initialState.password !== undefined ? initialState.password : '',
     );
-    const [passwordConfirm, setPasswordConfirm] = useState('');
+    const [passwordConfirm, setPasswordConfirm] = useState(
+      initialState.passwordConfirm !== undefined
+        ? initialState.passwordConfirm
+        : '',
+    );
     const [localId, setLocalId] = useState(
-      initialState.body !== undefined ? initialState.body.localId : '',
+      initialState.localId !== undefined ? initialState.localId : '',
     );
-    const [phoneNumber, setPhoneNumber] = useState('');
-    const [code, setCode] = useState('');
+    const [phoneNumber, setPhoneNumber] = useState(
+      initialState.phoneNumber !== undefined ? initialState.phoneNumber : '',
+    );
+    const [code, setCode] = useState(
+      initialState.code !== undefined ? initialState.code : '',
+    );
     const [username, setUsername] = useState(
-      initialState.body !== undefined ? initialState.body.username : '',
+      initialState.username !== undefined ? initialState.username : '',
     );
 
     const handleEmailChange = (input: string) => {

--- a/src/presentation/authPresentation.ts
+++ b/src/presentation/authPresentation.ts
@@ -8,7 +8,7 @@ type StringInput = {
 };
 
 type AuthPresentation = {
-  useValidator(): {
+  useValidator(initialState?: { body?: PreviousForm }): {
     snuMail: StringInput;
     password: StringInput;
     passwordConfirm: StringInput;
@@ -17,6 +17,13 @@ type AuthPresentation = {
     code: StringInput;
     username: StringInput;
   };
+};
+
+type PreviousForm = {
+  authProvider: 'LOCAL';
+  localId: string;
+  password: string;
+  username: string;
 };
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@snu\.ac\.kr$/;
@@ -34,14 +41,20 @@ const CODE_REGEX = /^\d{6}$/;
 const USERNAME_REGEX = /^([가-힣]{2,6}|[A-Za-z]{2,20})$/;
 
 export const authPresentation: AuthPresentation = {
-  useValidator: () => {
+  useValidator: (initialState = {}) => {
     const [email, setEmail] = useState('');
-    const [password, setPassword] = useState('');
+    const [password, setPassword] = useState(
+      initialState.body !== undefined ? initialState.body.password : '',
+    );
     const [passwordConfirm, setPasswordConfirm] = useState('');
-    const [localId, setLocalId] = useState('');
+    const [localId, setLocalId] = useState(
+      initialState.body !== undefined ? initialState.body.localId : '',
+    );
     const [phoneNumber, setPhoneNumber] = useState('');
     const [code, setCode] = useState('');
-    const [username, setUsername] = useState('');
+    const [username, setUsername] = useState(
+      initialState.body !== undefined ? initialState.body.username : '',
+    );
 
     const handleEmailChange = (input: string) => {
       setEmail(input);

--- a/src/presentation/authPresentation.ts
+++ b/src/presentation/authPresentation.ts
@@ -8,7 +8,7 @@ type StringInput = {
 };
 
 type AuthPresentation = {
-  useValidator(initialState?: { body?: PreviousForm }): {
+  useValidator({ initialState }: { initialState?: { body?: PreviousForm } }): {
     snuMail: StringInput;
     password: StringInput;
     passwordConfirm: StringInput;
@@ -41,7 +41,7 @@ const CODE_REGEX = /^\d{6}$/;
 const USERNAME_REGEX = /^([가-힣]{2,6}|[A-Za-z]{2,20})$/;
 
 export const authPresentation: AuthPresentation = {
-  useValidator: (initialState = {}) => {
+  useValidator: ({ initialState = {} }) => {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState(
       initialState.body !== undefined ? initialState.body.password : '',

--- a/src/shared/route/useRouteNavigation.ts
+++ b/src/shared/route/useRouteNavigation.ts
@@ -14,6 +14,13 @@ type VerifyMailBody =
       username: string;
     };
 
+type PreviousForm = {
+  authProvider: 'LOCAL';
+  localId: string;
+  password: string;
+  username: string;
+};
+
 export const useRouteNavigation = () => {
   const navigate = useNavigate();
   const {
@@ -41,8 +48,8 @@ export const useRouteNavigation = () => {
     toVerifyEmail: (body: VerifyMailBody) => {
       void navigate(VERIFY_EMAIL, { state: { body } });
     },
-    toSignUpLocal: () => {
-      void navigate(SIGN_UP_LOCAL);
+    toSignUpLocal: (body?: PreviousForm) => {
+      void navigate(SIGN_UP_LOCAL, { state: { body } });
     },
   };
 };


### PR DESCRIPTION
### 📝 작업 내용

- 이메일 인증 페이지에서 전송/재전송 버튼을 분리하였습니다.
- 이전 버튼을 추가하여 로컬 로그인 페이지로 이동하도록 설정하였습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- initialstate 문제로 authPresentation 부분이 변경되었습니다. 근데 삼항연산자가 너무 많기는 해서😂 이게 최선인지는 모르겠습니다..
