### PR TITLE
✨ progress bar 로컬 회원가입에만 적용

### DIFF
--- a/src/components/progressBar/ProgressBar.tsx
+++ b/src/components/progressBar/ProgressBar.tsx
@@ -1,0 +1,26 @@
+type ProgressBarProps = {
+  totalProgress: number;
+  present: number;
+};
+
+export const ProgressBar = ({ totalProgress, present }: ProgressBarProps) => {
+  const segmentStyle = (isActive: boolean): React.CSSProperties => ({
+    flex: 1,
+    backgroundColor: isActive ? 'gray' : 'lightgray',
+    margin: '0 2px',
+  });
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '5px',
+      }}
+    >
+      {Array.from({ length: totalProgress }).map((_, index) => (
+        <div key={index} style={segmentStyle(index < present)}></div>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
+++ b/src/pages/EmailVerifyPage/EmailVerifyForm.tsx
@@ -7,6 +7,7 @@ import { SubmitButton } from '@/components/button';
 import { FormContainer } from '@/components/form';
 import { TextInput } from '@/components/input';
 import { LabelContainer } from '@/components/input/LabelContainer';
+import { ProgressBar } from '@/components/progressBar/ProgressBar';
 import { authPresentation } from '@/presentation/authPresentation';
 import { useGuardContext } from '@/shared/context/hooks';
 import { ServiceContext } from '@/shared/context/ServiceContext';
@@ -120,6 +121,9 @@ export const EmailVerifyForm = () => {
           : googleSignUpResponseMessage
       }
     >
+      {body.authProvider === 'LOCAL' && (
+        <ProgressBar totalProgress={2} present={2} />
+      )}
       <LabelContainer label="이메일" id="email">
         <TextInput
           id="email"

--- a/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
+++ b/src/pages/LocalSignUpPage/LocalSignUpForm.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/button';
 import { FormContainer } from '@/components/form';
 import { TextInput } from '@/components/input';
 import { LabelContainer } from '@/components/input/LabelContainer';
+import { ProgressBar } from '@/components/progressBar/ProgressBar';
 import { authPresentation } from '@/presentation/authPresentation';
 import { useGuardContext } from '@/shared/context/hooks';
 import { ServiceContext } from '@/shared/context/ServiceContext';
@@ -91,6 +92,7 @@ export const LocalSignUpForm = () => {
         handleSubmit={onSubmit}
         response={responseMessage}
       >
+        <ProgressBar totalProgress={2} present={1} />
         <div>
           <LabelContainer label="이름" id="username">
             <TextInput


### PR DESCRIPTION
### 📝 작업 내용

- progress bar를 생성했습니다.
- 로컬회원가입에만 progress bar가 나타나도록 설정했습니다.

### 📸 스크린샷 (선택)
- 로컬 회원가입 시
![image](https://github.com/user-attachments/assets/2f11e85b-633a-4b70-b021-e56813279fdf)
![image](https://github.com/user-attachments/assets/26792ce5-53d6-4d88-a8fc-3c3540b11b48)

- 구글 회원가입 시
![image](https://github.com/user-attachments/assets/26c5b6a9-70a6-4124-a556-50bdaf3aeed5)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
