### PR TITLE
🚑 인증 토큰이 헤더에 들어가지 않는 문제 해결

### DIFF
--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/button';
 import { useGuardContext } from '@/shared/context/hooks.ts';
 import { ServiceContext } from '@/shared/context/ServiceContext.ts';
+import { TokenContext } from '@/shared/context/TokenContext';
 import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
 
 export const LandingPage = () => {
@@ -55,10 +56,14 @@ const useGetPosts = () => {
 
 const useLogout = () => {
   const { authService } = useGuardContext(ServiceContext);
+  const { token } = useGuardContext(TokenContext);
 
   const { mutate: logout, isPending } = useMutation({
     mutationFn: () => {
-      return authService.logout();
+      if (token === null) {
+        throw new Error('토큰이 존재하지 않습니다.');
+      }
+      return authService.logout({ token });
     },
   });
 

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -37,7 +37,6 @@ const useMyInfo = () => {
       if (t === null) {
         throw new Error('토큰이 존재하지 않습니다.');
       }
-      console.log(token);
       return userService.getMyInfo({ token: t });
     },
     enabled: token !== null,

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -37,6 +37,7 @@ const useMyInfo = () => {
       if (t === null) {
         throw new Error('토큰이 존재하지 않습니다.');
       }
+      console.log(token);
       return userService.getMyInfo({ token: t });
     },
     enabled: token !== null,

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -66,7 +66,7 @@ export type AuthService = {
     localId: string;
   }): ServiceResponse<void>;
   reissueAccessToken(): ServiceResponse<{ accessToken: string }>;
-  logout(): ServiceResponse<void>;
+  logout({ token }: { token: string }): ServiceResponse<void>;
 };
 
 export const implAuthService = ({
@@ -218,12 +218,10 @@ export const implAuthService = ({
     }
     return { type: 'error', status, message: data.error };
   },
-  logout: async () => {
-    const { status, data } = await apis['POST /user/logout']();
-
+  logout: async ({ token }) => {
+    const { status, data } = await apis['POST /user/logout']({ token });
     tokenLocalStorage.removeToken();
     tokenState.removeToken();
-
     if (status === 200) {
       return {
         type: 'success',

--- a/src/shared/api/api.ts
+++ b/src/shared/api/api.ts
@@ -116,10 +116,11 @@ export const getApis = ({ callWithToken, callWithoutToken }: GetApisProps) =>
         method: 'POST',
         path: 'user/token/refresh',
       }),
-    'POST /user/logout': () =>
-      callWithoutToken<SuccessResponse<void>>({
+    'POST /user/logout': ({ token }: { token: string }) =>
+      callWithToken<SuccessResponse<void>>({
         method: 'POST',
         path: 'user/logout',
+        token,
       }),
     'GET /user/info': ({ token }: { token: string }) =>
       callWithToken<SuccessResponse<UserResponse>>({

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -24,7 +24,7 @@ export const implApi = ({ externalCall }: ImplApiProps) => {
       headers: {
         'content-type': 'application/json;charset=UTF-8',
         ...(content.token !== undefined
-          ? { 'x-access-token': content.token }
+          ? { Authorization: `Bearer ${content.token}` }
           : {}),
       },
       credentials: 'include',

--- a/src/shared/auth/AuthProtectedRoute.tsx
+++ b/src/shared/auth/AuthProtectedRoute.tsx
@@ -10,11 +10,12 @@ import { TokenContext } from '@/shared/context/TokenContext';
 export const AuthProtectedRoute = () => {
   const hasReissued = useRef(false);
   const { token } = useGuardContext(TokenContext);
-  const { reissueToken, isPending } = useRefreshToken();
+  const { reissueToken } = useRefreshToken();
 
-  if (token === null && !isPending && !hasReissued.current) {
+  if (token === null && !hasReissued.current) {
     reissueToken();
     hasReissued.current = true;
+    return <div>로딩중...</div>;
   }
 
   return token === null ? <ReSignInModal /> : <Outlet />;
@@ -24,8 +25,15 @@ const useRefreshToken = () => {
   const { authService } = useGuardContext(ServiceContext);
 
   const { mutate: reissueToken, isPending } = useMutation({
-    mutationFn: () => {
-      return authService.reissueAccessToken();
+    mutationFn: async () => {
+      const response = await authService.reissueAccessToken();
+      return response;
+    },
+    onSuccess: () => {
+      return;
+    },
+    onError: () => {
+      return;
     },
   });
 

--- a/src/shared/auth/AuthProtectedRoute.tsx
+++ b/src/shared/auth/AuthProtectedRoute.tsx
@@ -24,7 +24,7 @@ export const AuthProtectedRoute = () => {
 const useRefreshToken = () => {
   const { authService } = useGuardContext(ServiceContext);
 
-  const { mutate: reissueToken, isPending } = useMutation({
+  const { mutate: reissueToken } = useMutation({
     mutationFn: async () => {
       const response = await authService.reissueAccessToken();
       return response;
@@ -39,6 +39,5 @@ const useRefreshToken = () => {
 
   return {
     reissueToken,
-    isPending,
   };
 };


### PR DESCRIPTION
### 📝 작업 내용

- 클라우드 프론트에서 모든 헤더를 서버로 전달하도록 설정하였습니다.
- 헤더에 'Authorization: Bearer {token}'의 방식으로 전달되도록 설정하였습니다.
- 로그아웃 시 토큰을 전달하도록 합니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
