### PR TITLE
💚 태그 푸시 대신 메인에 머지되면 배포되도록 변경

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -2,8 +2,8 @@ name: deploy-admin
 
 on:
   push:
-    tags:
-      - client*
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build & Export
         run: |
           yarn install
+          yarn build-pkg
           yarn build
 
       - name: Deploy to S3 and Invalidate Cloudfront in dev mode

--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -2,8 +2,8 @@ name: deploy-client
 
 on:
   push:
-    tags:
-      - client*
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "predev": "yarn --cwd ../.. build-pkg",
-    "dev": "yarn predev && vite --mode dev",
+    "pre:build-pkg": "yarn --cwd ../.. build-pkg",
+    "dev": "yarn pre:build-pkg && vite --mode dev",
     "mock": "vite --mode mock",
-    "build": "tsc -b && vite build --mode prod",
+    "build": "yarn pre:build-pkg && tsc -b && vite build --mode prod",
     "types:check": "tsc",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   ],
   "scripts": {
     "check-all": "yarn workspaces foreach -A run check",
-    "build-pkg": "yarn workspaces foreach -A run build:package"
+    "build-pkg": "yarn workspaces foreach -A run build:package",
+    "build": "yarn workspaces foreach -A run build"
   },
   "devDependencies": {
     "@types/node": "22.7.5",


### PR DESCRIPTION
### 📝 작업 내용

- 태그가 너무 많이 생겨 작업이 더 불편할 거 같아 메인 머지 시 자동 배포되도록 변경
(어차피 두 페이지 모두 서로 거의 유사)
- 추후 1.0.0이 배포되면 그때부터 태그푸시 도입이 필요할 듯

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
