### PR TITLE
✨ 회사 생성 페이지 생성

### DIFF
--- a/apps/admin/src/entities/input.ts
+++ b/apps/admin/src/entities/input.ts
@@ -9,3 +9,23 @@ export type SelectInput<TSelect> = {
   value: TSelect;
   onChange: (input: TSelect) => void;
 };
+
+export type ListInput<TElement> = {
+  isError: boolean;
+  value: TElement[];
+  onChange: ({
+    input,
+    index,
+    mode,
+  }:
+    | {
+        input: TElement;
+        index?: never;
+        mode: 'ADD' | 'REMOVE';
+      }
+    | {
+        input: TElement;
+        index: number;
+        mode: 'PATCH';
+      }) => void;
+};

--- a/apps/admin/src/feature/post/presentation/companypresentation.ts
+++ b/apps/admin/src/feature/post/presentation/companypresentation.ts
@@ -1,0 +1,370 @@
+import { useState } from 'react';
+
+import type { ListInput, SelectInput, StringInput } from '@/entities/input';
+
+export type Series = 'NONE' | 'SEED' | 'PRE_A' | 'A' | 'B' | 'C' | 'D';
+export const seriesList = ['SEED', 'PRE_A', 'A', 'B', 'C', 'D'];
+
+type ExternalLink = {
+  link: string;
+  description: string;
+};
+
+type InitialState = {
+  companyName?: string;
+  companyEmail?: string;
+  slogan?: string;
+  imageLink?: string;
+  series?: Series;
+  investAmount?: string;
+  investCompany?: string[];
+  tags?: string[];
+  IRDeckLink?: string;
+  landingPageLink?: string;
+  externalDescriptionLink?: ExternalLink[];
+};
+
+type CompanyPresentation = {
+  useValidator({ initialState }: { initialState?: InitialState }): {
+    companyName: StringInput;
+    companyEmail: StringInput;
+    slogan: StringInput;
+    imageLink: StringInput;
+    series: SelectInput<Series>;
+    investAmount: StringInput;
+    investCompany: ListInput<string>;
+    tags: ListInput<string>;
+    IRDeckLink: StringInput;
+    landingPageLink: StringInput;
+    externalDescriptionLink: ListInput<ExternalLink>;
+  };
+  useUtilState(): {
+    thumbnail: {
+      value: { file: File; url: string } | null;
+      onChange(input: { file: File; url: string } | null): void;
+    };
+    IRDeckPreview: {
+      value: { file: File; url: string } | null;
+      onChange(input: { file: File; url: string } | null): void;
+    };
+  };
+};
+
+const MAX_TAGS = 10;
+const CONTENT_REGEX = /^(?!\s*$).{1,500}$/;
+const TAG_REGEX = /^(?!\s*$).{1,8}$/;
+const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const URL_REGEX = /^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$/;
+
+export const companyPresentation: CompanyPresentation = {
+  useValidator: ({ initialState = {} }) => {
+    const [companyName, setCompanyName] = useState(
+      initialState.companyName !== undefined ? initialState.companyName : '',
+    );
+    const [companyEmail, setCompanyEmail] = useState(
+      initialState.companyEmail !== undefined ? initialState.companyEmail : '',
+    );
+    const [slogan, setSlogan] = useState(
+      initialState.slogan !== undefined ? initialState.slogan : '',
+    );
+    const [imageLink, setImageLink] = useState(
+      initialState.imageLink !== undefined ? initialState.imageLink : '',
+    );
+    const [series, setSeries] = useState<Series>(
+      initialState.series !== undefined ? initialState.series : 'NONE',
+    );
+    const [investAmount, setInvestAmount] = useState(
+      initialState.investAmount !== undefined ? initialState.investAmount : '',
+    );
+    const [investCompany, setInvestCompany] = useState<string[]>(
+      initialState.investCompany !== undefined
+        ? initialState.investCompany
+        : [''],
+    );
+    const [tags, setTags] = useState<string[]>(
+      initialState.tags !== undefined ? initialState.tags : [],
+    );
+    const [IRDeckLink, setIRDeckLink] = useState(
+      initialState.IRDeckLink !== undefined ? initialState.IRDeckLink : '',
+    );
+    const [landingPageLink, setLandingPageLink] = useState(
+      initialState.landingPageLink !== undefined
+        ? initialState.landingPageLink
+        : '',
+    );
+    const [externalDescriptionLink, setExternalDescriptionLink] = useState<
+      ExternalLink[]
+    >(
+      initialState.externalDescriptionLink !== undefined
+        ? initialState.externalDescriptionLink
+        : [{ link: '', description: '' }],
+    );
+
+    const isInvestCompanyExist = (input: string) => {
+      return input in investCompany;
+    };
+    const isTagExist = (input: string) => {
+      return input in tags;
+    };
+    const isExternalLinkExist = (input: ExternalLink) => {
+      return externalDescriptionLink.some(
+        (item) =>
+          item.link === input.link && item.description === input.description,
+      );
+    };
+    const isExternalLinkValid = (input: ExternalLink[]) => {
+      const filteredExternalLink = input.filter(
+        (item) =>
+          item.link.trim().length === 0 && item.description.trim().length,
+      );
+      return filteredExternalLink.every(
+        (externalLink) =>
+          URL_REGEX.test(externalLink.link) &&
+          CONTENT_REGEX.test(externalLink.description),
+      );
+    };
+    const isInvestCompanyValid = (input: string[]) => {
+      const filteredInvestCompany = input.filter(
+        (item) => item.trim().length === 0,
+      );
+      const hasDuplicates =
+        new Set(filteredInvestCompany).size !== filteredInvestCompany.length;
+      return (
+        filteredInvestCompany.every((company) => CONTENT_REGEX.test(company)) &&
+        !hasDuplicates &&
+        input.length < MAX_TAGS
+      );
+    };
+    const isTagsValid = (input: string[]) => {
+      const hasDuplicates = new Set(input).size !== input.length;
+      return (
+        input.every((company) => TAG_REGEX.test(company)) || !hasDuplicates
+      );
+    };
+
+    const handleCompanyNameChange = (input: string) => {
+      setCompanyName(input);
+    };
+    const handleCompanyEmailChange = (input: string) => {
+      setCompanyEmail(input);
+    };
+    const handleSloganChange = (input: string) => {
+      setSlogan(input);
+    };
+    const handleImageLinkChange = (input: string) => {
+      setImageLink(input);
+    };
+    const handleSeriesChange = (input: Series) => {
+      setSeries(input);
+    };
+    const handleInvestAmountChange = (input: string) => {
+      setInvestAmount(input);
+    };
+    const handleInvestCompanyChange = ({
+      input,
+      index,
+      mode,
+    }:
+      | {
+          input: string;
+          mode: 'ADD' | 'REMOVE';
+          index?: never;
+        }
+      | {
+          input: string;
+          mode: 'PATCH';
+          index: number;
+        }) => {
+      setInvestCompany((prevState) => {
+        switch (mode) {
+          case 'ADD':
+            return isInvestCompanyExist(input)
+              ? prevState
+              : [...prevState, input];
+
+          case 'REMOVE':
+            return prevState.filter((item) => item !== input);
+
+          case 'PATCH':
+            if (index < 0 || index >= prevState.length) {
+              return prevState;
+            }
+            return prevState.map((item, idx) => (idx === index ? input : item));
+
+          default:
+            return prevState;
+        }
+      });
+    };
+    const handleTagsChange = ({
+      input,
+      index,
+      mode,
+    }:
+      | {
+          input: string;
+          index?: never;
+          mode: 'ADD' | 'REMOVE';
+        }
+      | {
+          input: string;
+          index: number;
+          mode: 'PATCH';
+        }) => {
+      setTags((prevState) => {
+        switch (mode) {
+          case 'ADD':
+            return isTagExist(input) ? prevState : [...prevState, input];
+          case 'REMOVE':
+            return prevState.filter((item) => item !== input);
+          case 'PATCH':
+            if (index < 0 || index >= prevState.length) {
+              return prevState;
+            }
+            return prevState.map((item, idx) => (idx === index ? input : item));
+          default:
+            return prevState;
+        }
+      });
+    };
+    const handleIRDeckLinkChange = (input: string) => {
+      setIRDeckLink(input);
+    };
+    const handleLandingPageLinkChange = (input: string) => {
+      setLandingPageLink(input);
+    };
+    const handleExternalDescriptionLinkChange = ({
+      input,
+      index,
+      mode,
+    }:
+      | {
+          input: ExternalLink;
+          index?: never;
+          mode: 'ADD' | 'REMOVE';
+        }
+      | {
+          input: ExternalLink;
+          index: number;
+          mode: 'PATCH';
+        }) => {
+      setExternalDescriptionLink((prevState) => {
+        switch (mode) {
+          case 'ADD':
+            return isExternalLinkExist(input)
+              ? prevState
+              : [...prevState, input];
+
+          case 'REMOVE':
+            return prevState.filter(
+              (item) =>
+                !(
+                  item.link === input.link &&
+                  item.description === input.description
+                ),
+            );
+
+          case 'PATCH':
+            if (index < 0 || index >= prevState.length) {
+              return prevState;
+            }
+            return prevState.map((item, idx) => (idx === index ? input : item));
+
+          default:
+            return prevState;
+        }
+      });
+    };
+
+    return {
+      companyName: {
+        isError: !CONTENT_REGEX.test(companyName),
+        value: companyName,
+        onChange: handleCompanyNameChange,
+      },
+      companyEmail: {
+        isError: !EMAIL_REGEX.test(companyEmail),
+        value: companyEmail,
+        onChange: handleCompanyEmailChange,
+      },
+      slogan: {
+        isError: !CONTENT_REGEX.test(slogan),
+        value: slogan,
+        onChange: handleSloganChange,
+      },
+      imageLink: {
+        isError: !URL_REGEX.test(imageLink),
+        value: imageLink,
+        onChange: handleImageLinkChange,
+      },
+      series: {
+        isError: series !== 'NONE',
+        value: series,
+        onChange: handleSeriesChange,
+      },
+      investAmount: {
+        isError: isNaN(Number(investAmount)) || Number(investAmount) < 0,
+        value: investAmount,
+        onChange: handleInvestAmountChange,
+      },
+      investCompany: {
+        isError: !isInvestCompanyValid(investCompany),
+        value: investCompany,
+        onChange: handleInvestCompanyChange,
+      },
+      tags: {
+        isError: isTagsValid(tags),
+        value: tags,
+        onChange: handleTagsChange,
+      },
+      IRDeckLink: {
+        isError: !URL_REGEX.test(IRDeckLink),
+        value: IRDeckLink,
+        onChange: handleIRDeckLinkChange,
+      },
+      landingPageLink: {
+        isError: !URL_REGEX.test(landingPageLink),
+        value: landingPageLink,
+        onChange: handleLandingPageLinkChange,
+      },
+      externalDescriptionLink: {
+        isError: !isExternalLinkValid(externalDescriptionLink),
+        value: externalDescriptionLink,
+        onChange: handleExternalDescriptionLinkChange,
+      },
+    };
+  },
+  useUtilState: () => {
+    const [thumbnail, setThumbnail] = useState<{
+      file: File;
+      url: string;
+    } | null>(null);
+    const [IRDeckPreview, setIRDeckPreview] = useState<{
+      file: File;
+      url: string;
+    } | null>(null);
+
+    const handleThumbnailChange = (
+      input: {
+        file: File;
+        url: string;
+      } | null,
+    ) => {
+      setThumbnail(input);
+    };
+    const handleIRDeckPreview = (input: { file: File; url: string } | null) => {
+      setIRDeckPreview(input);
+    };
+
+    return {
+      thumbnail: {
+        value: thumbnail,
+        onChange: handleThumbnailChange,
+      },
+      IRDeckPreview: {
+        value: IRDeckPreview,
+        onChange: handleIRDeckPreview,
+      },
+    };
+  },
+};

--- a/apps/admin/src/feature/post/presentation/postPresentation.ts
+++ b/apps/admin/src/feature/post/presentation/postPresentation.ts
@@ -58,27 +58,22 @@ export const postPresentation: PostPresentation = {
     const [title, setTitle] = useState(
       initialState.title !== undefined ? initialState.title : '',
     );
-
     const [jobMajorCategory, setJobMajorCategory] = useState<JobMajorCategory>(
       initialState.jobMajorCategory !== undefined
         ? initialState.jobMajorCategory
         : 'DEVELOPMENT',
     );
-
     const [jobMinorCategory, setJobMinorCategory] = useState<JobMinorCategory>(
       initialState.jobMinorCategory !== undefined
         ? initialState.jobMinorCategory
         : 'NONE',
     );
-
     const [headcount, setHeadcount] = useState(
       initialState.headcount !== undefined ? initialState.headcount : '',
     );
-
     const [content, setContent] = useState(
       initialState.content !== undefined ? initialState.content : '',
     );
-
     const [employmentEndDate, setEmploymentEndDate] = useState(
       initialState.employmentEndDate !== undefined
         ? initialState.employmentEndDate

--- a/apps/admin/src/feature/post/ui/CreateCompanyForm.tsx
+++ b/apps/admin/src/feature/post/ui/CreateCompanyForm.tsx
@@ -1,27 +1,273 @@
 import {
+  Button,
   FormContainer,
   LabelContainer,
   TextInput,
 } from '@waffle/design-system';
+import { useState } from 'react';
+
+import {
+  type Series,
+  seriesList,
+} from '@/feature/post/presentation/companypresentation';
+import { companyPresentation } from '@/feature/post/presentation/companypresentation';
 
 export const CreateCompanyForm = () => {
-  const handleSubmit = () => {};
+  const [rawTagValue, setRawTagValue] = useState('');
+  const {
+    companyName,
+    companyEmail,
+    slogan,
+    tags,
+    series,
+    investAmount,
+    investCompany,
+    landingPageLink,
+    externalDescriptionLink,
+  } = companyPresentation.useValidator({});
+  const { thumbnail, IRDeckPreview } = companyPresentation.useUtilState();
+
+  const handleSubmit = () => {
+    console.log(thumbnail);
+  };
+
+  const addThumbnailImage = (file: File | undefined) => {
+    if (file !== undefined && file.type.startsWith('image/')) {
+      thumbnail.onChange({ file, url: URL.createObjectURL(file) });
+    }
+  };
+
+  const removeImage = () => {
+    thumbnail.onChange(null);
+  };
+
+  const addPdfPreview = (file: File | undefined) => {
+    if (file !== undefined && file.type === 'application/pdf') {
+      IRDeckPreview.onChange({ file, url: URL.createObjectURL(file) });
+    }
+  };
+
+  const removePdf = () => {
+    IRDeckPreview.onChange(null);
+  };
   return (
     <FormContainer handleSubmit={handleSubmit} response={''}>
       <LabelContainer label="회사명" id="companyName">
-        <TextInput />
+        <TextInput
+          id="companyName"
+          value={companyName.value}
+          onChange={(e) => {
+            companyName.onChange(e.target.value);
+          }}
+        />
       </LabelContainer>
-      <p>회사명</p>
-      <p>회사 이메일</p>
-      <p>한 줄 소개</p>
-      <p>해시태그</p>
-      <p>시리즈</p>
-      <p>누적 투자액</p>
-      <p>투자사 정보</p>
-      <p>썸네일 이미지</p>
-      <p>IR Deck 자료</p>
-      <p>기업소개 랜딩 페이지</p>
-      <p>외부 소개 링크</p>
+      <LabelContainer label="회사 이메일" id="companyEmail">
+        <TextInput
+          id="companyEmail"
+          value={companyEmail.value}
+          onChange={(e) => {
+            companyEmail.onChange(e.target.value);
+          }}
+        />
+      </LabelContainer>
+      <LabelContainer label="한 줄 소개" id="slogan">
+        <TextInput
+          id="slogan"
+          value={slogan.value}
+          onChange={(e) => {
+            slogan.onChange(e.target.value);
+          }}
+        />
+      </LabelContainer>
+      <LabelContainer label="대표 사진" id="imageLink">
+        {thumbnail.value !== null ? (
+          <div>
+            <img src={thumbnail.value.url} alt="회사 대표 이미지 썸네일" />
+            <Button onClick={removeImage}>삭제</Button>
+          </div>
+        ) : (
+          <label htmlFor="fileInput">
+            <span>이미지 등록</span>
+          </label>
+        )}
+        <input
+          id="fileInput"
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={(e) => {
+            console.log('here');
+            if (e.target.files !== null) {
+              console.log(e.target.files);
+              addThumbnailImage(e.target.files[0]);
+            }
+          }}
+        />
+      </LabelContainer>
+      <LabelContainer label="투자 단계" id="series">
+        <select
+          onChange={(e) => {
+            if (seriesList.includes(e.target.value)) {
+              series.onChange(e.target.value as Series);
+            }
+          }}
+        >
+          {seriesList.map((seriesItem, idx) => (
+            <option key={idx} value={seriesItem}>
+              {seriesItem}
+            </option>
+          ))}
+        </select>
+      </LabelContainer>
+      <LabelContainer label="누적 투자액" id="investAmount">
+        <TextInput
+          id="investAmount"
+          value={investAmount.value}
+          onChange={(e) => {
+            investAmount.onChange(e.target.value);
+          }}
+        />
+        <span>천만원</span>
+      </LabelContainer>
+      <LabelContainer label="투자사 정보" id="investCompany">
+        {investCompany.value.map((input, index) => (
+          <div key={`invest-company-${index}`}>
+            <TextInput
+              value={input}
+              onChange={(e) => {
+                investCompany.onChange({
+                  input: e.target.value,
+                  index,
+                  mode: 'PATCH',
+                });
+              }}
+            />
+            <Button
+              onClick={() => {
+                investCompany.onChange({ input, mode: 'REMOVE' });
+              }}
+            >
+              삭제
+            </Button>
+          </div>
+        ))}
+        <Button
+          onClick={() => {
+            investCompany.onChange({ input: '', mode: 'ADD' });
+          }}
+        >
+          추가
+        </Button>
+      </LabelContainer>
+      <LabelContainer label="해시태그" id="tags">
+        <TextInput
+          value={rawTagValue}
+          placeholder="회사를 소개하는 태그를 입력해주세요. (최대 10개)"
+          onChange={(e) => {
+            setRawTagValue(e.target.value);
+          }}
+          onKeyDown={(e) => {
+            e.preventDefault();
+            if (e.key === 'Enter' && rawTagValue.trim() !== '') {
+              tags.onChange({ input: rawTagValue.trim(), mode: 'ADD' });
+              setRawTagValue('');
+            }
+          }}
+        />
+        <p>태그는 띄어쓰기로 구분되며 한 개당 최대 8자까지 입력할 수 있어요.</p>
+      </LabelContainer>
+      <LabelContainer label="IR Deck 자료" id="IRDeckLink">
+        {IRDeckPreview.value !== null ? (
+          <div>
+            <p>{IRDeckPreview.value.file.name}</p>
+            <Button onClick={removePdf}>삭제</Button>
+          </div>
+        ) : (
+          <label htmlFor="pdfInput">
+            <span>PDF 파일만 업로드 가능해요.</span>
+          </label>
+        )}
+        <input
+          id="pdfInput"
+          type="file"
+          accept="application/pdf"
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files !== null) {
+              console.log(e.target.files);
+              addPdfPreview(e.target.files[0]);
+            }
+          }}
+        />
+      </LabelContainer>
+      <LabelContainer label="기업 소개 홈페이지">
+        <TextInput
+          id="landingPageLink"
+          value={landingPageLink.value}
+          placeholder="https://"
+          onChange={(e) => {
+            landingPageLink.onChange(e.target.value);
+          }}
+        />
+      </LabelContainer>
+      <LabelContainer label="외부 소개 링크" id="externalDescriptionLink">
+        {externalDescriptionLink.value.map((input, index) => (
+          <div key={`external-link-${index}`}>
+            <div>
+              <LabelContainer label="제목">
+                <TextInput
+                  value={input.link}
+                  placeholder="링크 제목을 작성해주세요. (e.g. OO 프로젝트 성과 기사)"
+                  onChange={(e) => {
+                    externalDescriptionLink.onChange({
+                      input: {
+                        link: e.target.value,
+                        description: input.description,
+                      },
+                      index,
+                      mode: 'PATCH',
+                    });
+                  }}
+                />
+              </LabelContainer>
+              <LabelContainer label="링크">
+                <TextInput
+                  value={input.description}
+                  placeholder="https://"
+                  onChange={(e) => {
+                    externalDescriptionLink.onChange({
+                      input: { link: input.link, description: e.target.value },
+                      index,
+                      mode: 'PATCH',
+                    });
+                  }}
+                />
+              </LabelContainer>
+              <Button
+                onClick={() => {
+                  externalDescriptionLink.onChange({ input, mode: 'REMOVE' });
+                }}
+              >
+                삭제
+              </Button>
+            </div>
+          </div>
+        ))}
+        <Button
+          onClick={() => {
+            externalDescriptionLink.onChange({
+              input: { link: '', description: '' },
+              mode: 'ADD',
+            });
+          }}
+        >
+          추가
+        </Button>
+        <p>
+          더벤처스, 잡코리아, 기사 링크 등 회사를 소개할 수 있는 기타 링크를
+          첨부해주세요.
+        </p>
+      </LabelContainer>
     </FormContainer>
   );
 };

--- a/packages/design-system/src/Button/Button.tsx
+++ b/packages/design-system/src/Button/Button.tsx
@@ -22,9 +22,7 @@ const buttonVariants = cva(
 
 interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  onClick?: () => void;
-}
+    VariantProps<typeof buttonVariants> {}
 
 export const Button = ({
   children,


### PR DESCRIPTION
### 📝 작업 내용

- 회사 생성 페이지를 만듭니다.

### TODO
- presigned url을 사용하여 업로드를 구현해야 합니다.
- 공고 생성 페이지와 연결해야 합니다.

### 📸 스크린샷 (선택)
- 다중 string input
![image](https://github.com/user-attachments/assets/7a65d6b4-4e59-49b7-b447-5515a8ea6c06)

- 이미지 업로드 시 썸네일 확인 가능
![image](https://github.com/user-attachments/assets/8dd4cf6b-26de-4606-9099-e6d6ca62c5d5)

- pdf 업로드 시 업로드한 파일의 제목 확인 가능
![image](https://github.com/user-attachments/assets/24296a1b-f05c-406b-acdd-c853c8c7632c)

- 다중 객체 input
![image](https://github.com/user-attachments/assets/b12e3497-ce7a-4516-9b87-9bb11620d314)

- 해시태그 입력창 (공백 허용, 공백만 있을 시 태그 생성 불가)
![image](https://github.com/user-attachments/assets/7b57b25d-1ca9-4b89-9558-80c6bcd8395c)



### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
