### PR TITLE
companyPresentation 계층에서 input과 form에 사용하는 상태 함께 관리

### DIFF
--- a/apps/client/src/components/field/ImageField.tsx
+++ b/apps/client/src/components/field/ImageField.tsx
@@ -11,6 +11,7 @@ type ImageFieldProps = {
   input: InputType<{ file: File; url: string } | null>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   responseErrorMessage?: string;
   infoMessage?: string;
@@ -22,13 +23,14 @@ export const ImageField = ({
   input,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   responseErrorMessage,
   infoMessage,
   required,
 }: ImageFieldProps) => {
   const addImage = (file: File | undefined) => {
-    if (file !== undefined && file.type.startsWith('image/')) {
+    if (file !== undefined) {
       input.onChange({ file, url: URL.createObjectURL(file) });
     }
   };
@@ -37,9 +39,11 @@ export const ImageField = ({
     input.onChange(null);
   };
 
+  const showError = (!isSubmit && input.isError) || (isSubmit && isSubmitError);
+
   return (
     <LabelContainer label={label} required={required}>
-      {input.value !== null ? (
+      {input.value !== null && !input.isError ? (
         <div>
           <img src={input.value.url} alt="썸네일" />
           <Button onClick={removeImage} disabled={isPending}>
@@ -67,9 +71,7 @@ export const ImageField = ({
         {infoMessage !== undefined && (
           <FormInfoResponse>{infoMessage}</FormInfoResponse>
         )}
-        {isSubmit && input.isError && (
-          <FormErrorResponse>{errorMessage}</FormErrorResponse>
-        )}
+        {showError && <FormErrorResponse>{errorMessage}</FormErrorResponse>}
         {responseErrorMessage !== '' && (
           <FormErrorResponse>{responseErrorMessage}</FormErrorResponse>
         )}

--- a/apps/client/src/components/field/MarkdownEditorField.tsx
+++ b/apps/client/src/components/field/MarkdownEditorField.tsx
@@ -12,6 +12,7 @@ type MarkdownEditorFieldProps = {
   input: InputType<string>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   maxLength: number;
   infoMessage?: string;
@@ -23,6 +24,7 @@ export const MarkdownEditorField = ({
   input,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   infoMessage,
   required,
@@ -49,7 +51,7 @@ export const MarkdownEditorField = ({
               {input.value.length}/{maxLength}
             </span>
           </div>
-          {isSubmit && input.isError && (
+          {isSubmit && isSubmitError && (
             <FormErrorResponse>{errorMessage}</FormErrorResponse>
           )}
         </div>

--- a/apps/client/src/components/field/PdfField.tsx
+++ b/apps/client/src/components/field/PdfField.tsx
@@ -11,6 +11,7 @@ type PdfFieldProps = {
   input: InputType<{ file: File; url: string } | null>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   responseErrorMessage?: string;
   infoMessage?: string;
@@ -22,13 +23,14 @@ export const PdfField = ({
   input,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   responseErrorMessage,
   infoMessage,
   required,
 }: PdfFieldProps) => {
   const addPdfPreview = (file: File | undefined) => {
-    if (file !== undefined && file.type === 'application/pdf') {
+    if (file !== undefined) {
       input.onChange({ file, url: URL.createObjectURL(file) });
     }
   };
@@ -36,6 +38,9 @@ export const PdfField = ({
   const removePdf = () => {
     input.onChange(null);
   };
+
+  const showError = (!isSubmit && input.isError) || (isSubmit && isSubmitError);
+
   return (
     <LabelContainer label={label} required={required}>
       {input.value !== null ? (
@@ -66,9 +71,7 @@ export const PdfField = ({
         {infoMessage !== undefined && (
           <FormInfoResponse>{infoMessage}</FormInfoResponse>
         )}
-        {isSubmit && input.isError && (
-          <FormErrorResponse>{errorMessage}</FormErrorResponse>
-        )}
+        {showError && <FormErrorResponse>{errorMessage}</FormErrorResponse>}
         {responseErrorMessage !== '' && <p>{responseErrorMessage}</p>}
       </div>
     </LabelContainer>

--- a/apps/client/src/components/field/StringField.tsx
+++ b/apps/client/src/components/field/StringField.tsx
@@ -11,6 +11,7 @@ type StringFieldProps = {
   input: InputType<string>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   infoMessage?: string;
   required?: boolean;
@@ -22,6 +23,7 @@ export const StringField = ({
   input,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   infoMessage,
   required,
@@ -39,7 +41,7 @@ export const StringField = ({
       />
       <div className="flex flex-col gap-1">
         <FormInfoResponse>{infoMessage}</FormInfoResponse>
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>

--- a/apps/client/src/components/field/StringSelectForm.tsx
+++ b/apps/client/src/components/field/StringSelectForm.tsx
@@ -11,6 +11,7 @@ type StringSelectFormProps<T extends string> = {
   inputList: string[];
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   infoMessage?: string;
   required?: boolean;
@@ -22,6 +23,7 @@ export const StringSelectForm = <T extends string>({
   inputList,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   infoMessage,
   required,
@@ -52,7 +54,7 @@ export const StringSelectForm = <T extends string>({
         {infoMessage !== undefined && (
           <FormInfoResponse>{infoMessage}</FormInfoResponse>
         )}
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>

--- a/apps/client/src/components/field/StringWithLetterCountField.tsx
+++ b/apps/client/src/components/field/StringWithLetterCountField.tsx
@@ -11,6 +11,7 @@ type StringWithLetterCountFieldProps = {
   input: InputType<string>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   maxLength: number;
   infoMessage?: string;
@@ -23,6 +24,7 @@ export const StringWithLetterCountField = ({
   input,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   infoMessage,
   required,
@@ -48,7 +50,7 @@ export const StringWithLetterCountField = ({
             {input.value.length}/{maxLength}
           </span>
         </div>
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>

--- a/apps/client/src/entities/input.ts
+++ b/apps/client/src/entities/input.ts
@@ -29,3 +29,8 @@ export type ListInput<TElement> = {
         mode: 'PATCH';
       }) => void;
 };
+
+export type InputForForm<TInput> = {
+  isError: boolean;
+  value: TInput;
+};

--- a/apps/client/src/entities/input.ts
+++ b/apps/client/src/entities/input.ts
@@ -21,12 +21,12 @@ export type ListInput<TElement> = {
     | {
         input: TElement;
         index?: never;
-        mode: 'ADD' | 'REMOVE';
+        mode: 'ADD';
       }
     | {
         input: TElement;
         index: number;
-        mode: 'PATCH';
+        mode: 'PATCH' | 'REMOVE';
       }) => void;
 };
 

--- a/apps/client/src/entities/post.ts
+++ b/apps/client/src/entities/post.ts
@@ -26,6 +26,7 @@ export const JOB_MAJOR_CATEGORIES = Object.keys(JOB_CATEGORY_MAP);
 export const JOB_MINOR_CATEGORIES = Object.values(JOB_CATEGORY_MAP).flat();
 
 export type Series = 'SEED' | 'PRE_A' | 'A' | 'B' | 'C' | 'D';
+export const seriesList = ['SEED', 'PRE_A', 'A', 'B', 'C', 'D'];
 
 export type FilterElements = {
   roles?: JobMinorCategory[];

--- a/apps/client/src/feature/company/presentation/companyFormPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyFormPresentation.ts
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 
 import type { Input, ListInput, SelectInput } from '@/entities/input';
-import type { Series } from '@/entities/post';
+import type { Series, seriesList } from '@/entities/post';
 
-export const seriesList = ['SEED', 'PRE_A', 'A', 'B', 'C', 'D'];
+import type { CompanyInputPresentation } from './companyInputPresentation';
 
 type ExternalLink = {
   link: string;
@@ -25,35 +25,43 @@ type InitialState = {
   externalDescriptionLink?: ExternalLink[];
 };
 
-type CompanyPresentation = {
-  useValidator({ initialState }: { initialState?: InitialState }): {
-    companyName: Input<string>;
-    explanation: Input<string>;
-    email: Input<string>;
-    slogan: Input<string>;
-    imageLink: Input<string>;
-    series: SelectInput<Series | 'NONE'>;
-    investAmount: Input<string>;
-    investCompany: ListInput<string>;
-    tag: Input<string>;
-    tags: ListInput<string>;
-    IRDeckLink: Input<string>;
-    landingPageLink: Input<string>;
-    externalDescriptionLink: ListInput<ExternalLink>;
-  };
-  useUtilState(): {
-    rawTags: Input<string>;
-    thumbnail: Input<{ file: File; url: string } | null>;
-    IRDeckPreview: Input<{ file: File; url: string } | null>;
-  };
-  validator: {
-    tagValidator({ tag, tags }: { tag: string; tags: string[] }): boolean;
-    tagInputValidator({ tag, tags }: { tag: string; tags: string[] }): boolean;
-  };
-  filter: {
-    tagsFilter: (input: string[]) => string[];
-    investCompanyFilter: (input: string[]) => string[];
-    externalDescriptionLinkFilter: (input: ExternalLink[]) => ExternalLink[];
+type CompanyFormPresentation = {
+  useValidator({
+    initialState,
+    companyInputPresentation,
+  }: {
+    initialState?: InitialState;
+    companyInputPresentation: CompanyInputPresentation;
+  }): {
+    input: {
+      companyName: Input<string>;
+      explanation: Input<string>;
+      email: Input<string>;
+      slogan: Input<string>;
+      investAmount: Input<string>;
+      investCompany: ListInput<string>;
+      series: SelectInput<Series | 'NONE'>;
+      irDeckPreview: Input<{ file: File; url: string } | null>;
+      landingPageLink: Input<string>;
+      imagePreview: Input<{ file: File; url: string } | null>;
+      externalDescriptionLink: ListInput<ExternalLink>;
+      rawTag: Input<string>;
+      tags: ListInput<string>;
+    };
+    form: {
+      companyName: Input<string>;
+      explanation: Input<string>;
+      email: Input<string>;
+      slogan: Input<string>;
+      investAmount: Input<number>;
+      investCompany: ListInput<string>;
+      series: SelectInput<Series | 'NONE'>;
+      irDeckLink: Input<string>;
+      landingPageLink: Input<string>;
+      imageLink: Input<string>;
+      externalDescriptionLink: ListInput<ExternalLink>;
+      tags: ListInput<string>;
+    };
   };
 };
 
@@ -84,8 +92,8 @@ const TAG_REGEX = /^(?!\s*$).{1,8}$/;
 const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const URL_REGEX = /^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$/;
 
-export const companyPresentation: CompanyPresentation = {
-  useValidator: ({ initialState = {} }) => {
+export const companyFormPresentation: CompanyFormPresentation = {
+  useValidator: ({ initialState = {}, companyInputPresentation }) => {
     const [companyName, setCompanyName] = useState(
       initialState.companyName !== undefined ? initialState.companyName : '',
     );

--- a/apps/client/src/feature/company/presentation/companyFormPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyFormPresentation.ts
@@ -47,8 +47,10 @@ type CompanyFormPresentation = {
       investCompany: ListInput<string>;
       series: SelectInput<Series | 'NONE'>;
       irDeckPreview: Input<{ file: File; url: string } | null>;
+      irDeckLink: Input<string>;
       landingPageLink: Input<string>;
       imagePreview: Input<{ file: File; url: string } | null>;
+      imageLink: Input<string>;
       rawExternalDescriptionLink: Input<ExternalLink>;
       externalDescriptionLink: ListInput<ExternalLink>;
       rawTag: Input<string>;
@@ -60,7 +62,7 @@ type CompanyFormPresentation = {
       email: InputForForm<string>;
       slogan: InputForForm<string>;
       investAmount: InputForForm<number>;
-      investCompany: InputForForm<string[]>;
+      investCompany: InputForForm<string>;
       series: InputForForm<Series | 'NONE'>;
       irDeckLink: InputForForm<string>;
       landingPageLink: InputForForm<string>;
@@ -78,7 +80,10 @@ export const companyFormPresentation: CompanyFormPresentation = {
       explanation: initialState?.explanation,
       email: initialState?.email,
       slogan: initialState?.slogan,
-      investAmount: String(initialState?.investAmount),
+      investAmount:
+        initialState !== undefined
+          ? String(initialState.investAmount)
+          : undefined,
       investCompany: initialState?.investCompany,
       series: initialState?.series,
       irDeckPreview: initialState?.irDeckPreview,
@@ -121,27 +126,49 @@ export const companyFormPresentation: CompanyFormPresentation = {
         investCompany,
         series,
         irDeckPreview,
+        irDeckLink,
         landingPageLink,
         imagePreview,
+        imageLink,
         rawExternalDescriptionLink,
         externalDescriptionLink,
         rawTag,
         tags,
       },
       formStates: {
-        companyName: companyName,
-        explanation: explanation,
-        email: email,
-        slogan: slogan,
-        imageLink: imageLink,
-        series: series,
+        companyName: {
+          isError: companyName.isError || companyName.value.trim().length === 0,
+          value: companyName.value,
+        },
+        explanation: {
+          isError: explanation.isError || explanation.value.trim().length === 0,
+          value: explanation.value,
+        },
+        email: {
+          isError: email.isError || email.value.trim().length === 0,
+          value: email.value,
+        },
+        slogan: {
+          isError: slogan.isError || slogan.value.trim().length === 0,
+          value: slogan.value,
+        },
+        imageLink: {
+          isError: imageLink.isError || imageLink.value.trim().length === 0,
+          value: imageLink.value,
+        },
+        series: {
+          isError: series.isError || series.value === 'NONE',
+          value: series.value,
+        },
         investAmount: {
           isError: isNaN(Number(investAmount)) || Number(investAmount) < 0,
           value: Number(investAmount),
         },
         investCompany: {
-          isError: investCompany.isError,
-          value: investCompany.value.filter((item) => item.trim().length !== 0),
+          isError: investCompany.isError || investCompany.value.length === 0,
+          value: investCompany.value
+            .filter((item) => item.trim().length !== 0)
+            .join(','),
         },
         tags: tags,
         irDeckLink: irDeckLink,

--- a/apps/client/src/feature/company/presentation/companyFormPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyFormPresentation.ts
@@ -1,9 +1,11 @@
-import { useState } from 'react';
-
-import type { Input, ListInput, SelectInput } from '@/entities/input';
-import type { Series, seriesList } from '@/entities/post';
-
-import type { CompanyInputPresentation } from './companyInputPresentation';
+import type {
+  Input,
+  InputForForm,
+  ListInput,
+  SelectInput,
+} from '@/entities/input';
+import type { Series } from '@/entities/post';
+import type { CompanyInputPresentation } from '@/feature/company/presentation/companyInputPresentation';
 
 type ExternalLink = {
   link: string;
@@ -15,14 +17,16 @@ type InitialState = {
   explanation?: string;
   email?: string;
   slogan?: string;
-  imageLink?: string;
-  series?: Series | 'NONE';
-  investAmount?: string;
+  investAmount?: number;
   investCompany?: string[];
-  tags?: string[];
-  IRDeckLink?: string;
+  series?: Series | 'NONE';
+  irDeckPreview?: { file: File; url: string } | null;
+  irDeckLink?: string;
   landingPageLink?: string;
+  imagePreview?: { file: File; url: string } | null;
+  imageLink?: string;
   externalDescriptionLink?: ExternalLink[];
+  tags?: string[];
 };
 
 type CompanyFormPresentation = {
@@ -33,489 +37,124 @@ type CompanyFormPresentation = {
     initialState?: InitialState;
     companyInputPresentation: CompanyInputPresentation;
   }): {
-    input: {
+    inputStates: {
       companyName: Input<string>;
       explanation: Input<string>;
       email: Input<string>;
       slogan: Input<string>;
       investAmount: Input<string>;
+      rawInvestCompany: Input<string>;
       investCompany: ListInput<string>;
       series: SelectInput<Series | 'NONE'>;
       irDeckPreview: Input<{ file: File; url: string } | null>;
       landingPageLink: Input<string>;
       imagePreview: Input<{ file: File; url: string } | null>;
+      rawExternalDescriptionLink: Input<ExternalLink>;
       externalDescriptionLink: ListInput<ExternalLink>;
       rawTag: Input<string>;
       tags: ListInput<string>;
     };
-    form: {
-      companyName: Input<string>;
-      explanation: Input<string>;
-      email: Input<string>;
-      slogan: Input<string>;
-      investAmount: Input<number>;
-      investCompany: ListInput<string>;
-      series: SelectInput<Series | 'NONE'>;
-      irDeckLink: Input<string>;
-      landingPageLink: Input<string>;
-      imageLink: Input<string>;
-      externalDescriptionLink: ListInput<ExternalLink>;
-      tags: ListInput<string>;
+    formStates: {
+      companyName: InputForForm<string>;
+      explanation: InputForForm<string>;
+      email: InputForForm<string>;
+      slogan: InputForForm<string>;
+      investAmount: InputForForm<number>;
+      investCompany: InputForForm<string[]>;
+      series: InputForForm<Series | 'NONE'>;
+      irDeckLink: InputForForm<string>;
+      landingPageLink: InputForForm<string>;
+      imageLink: InputForForm<string>;
+      externalDescriptionLink: InputForForm<ExternalLink[]>;
+      tags: InputForForm<string[]>;
     };
   };
 };
 
-const MAX_TAGS = 10;
-const MAX_TAG_LENGTH = 8;
-const MAX_COMPANY_LENGTH = 30;
-export const MAX_SLOGAN_LENGTH = 100;
-export const MAX_EXPLANATION_LENGTH = 5000;
-const MAX_IMAGE_SIZE = 1 * 1024 * 1024;
-const MAX_FILE_SIZE = 5 * 1024 * 2024;
-const IMAGE_EXTENSIONS = [
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'bmp',
-  'webp',
-  'svg',
-  'tiff',
-  'ico',
-  'heif',
-  'heic',
-];
-const FILE_EXTENSIONS = ['pdf'];
-
-const CONTENT_REGEX = /^(?!\s*$).{1,500}$/;
-const TAG_REGEX = /^(?!\s*$).{1,8}$/;
-const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-const URL_REGEX = /^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$/;
-
 export const companyFormPresentation: CompanyFormPresentation = {
-  useValidator: ({ initialState = {}, companyInputPresentation }) => {
-    const [companyName, setCompanyName] = useState(
-      initialState.companyName !== undefined ? initialState.companyName : '',
-    );
-    const [explanation, setExplanation] = useState(
-      initialState.explanation !== undefined ? initialState.explanation : '',
-    );
-    const [email, setEmail] = useState(
-      initialState.email !== undefined ? initialState.email : '',
-    );
-    const [slogan, setSlogan] = useState(
-      initialState.slogan !== undefined ? initialState.slogan : '',
-    );
-    const [imageLink, setImageLink] = useState(
-      initialState.imageLink !== undefined ? initialState.imageLink : '',
-    );
-    const [series, setSeries] = useState<Series | 'NONE'>(
-      initialState.series !== undefined ? initialState.series : 'NONE',
-    );
-    const [investAmount, setInvestAmount] = useState(
-      initialState.investAmount !== undefined ? initialState.investAmount : '',
-    );
-    const [investCompany, setInvestCompany] = useState<string[]>(
-      initialState.investCompany !== undefined
-        ? initialState.investCompany
-        : [''],
-    );
-    const [tag, setTag] = useState('');
-    const [tags, setTags] = useState<string[]>(
-      initialState.tags !== undefined ? initialState.tags : [],
-    );
-    const [IRDeckLink, setIRDeckLink] = useState(
-      initialState.IRDeckLink !== undefined ? initialState.IRDeckLink : '',
-    );
-    const [landingPageLink, setLandingPageLink] = useState(
-      initialState.landingPageLink !== undefined
-        ? initialState.landingPageLink
-        : '',
-    );
-    const [externalDescriptionLink, setExternalDescriptionLink] = useState<
-      ExternalLink[]
-    >(
-      initialState.externalDescriptionLink !== undefined
-        ? initialState.externalDescriptionLink
-        : [{ link: '', description: '' }],
-    );
-
-    const isInvestCompanyExist = (input: string) => {
-      return input in investCompany;
-    };
-    const isExternalLinkExist = (input: ExternalLink) => {
-      return externalDescriptionLink.some(
-        (item) =>
-          item.link === input.link && item.description === input.description,
-      );
-    };
-    const isExternalLinkValid = (input: ExternalLink[]) => {
-      const filteredExternalLink = input.filter(
-        (item) =>
-          item.link.trim().length !== 0 && item.description.trim().length !== 0,
-      );
-      return filteredExternalLink.every(
-        (externalLink) =>
-          URL_REGEX.test(externalLink.link) &&
-          CONTENT_REGEX.test(externalLink.description),
-      );
-    };
-    const isInvestCompanyValid = (input: string[]) => {
-      const filteredInvestCompany = input.filter(
-        (item) => item.trim().length !== 0,
-      );
-      const hasDuplicates =
-        new Set(filteredInvestCompany).size !== filteredInvestCompany.length;
-      return (
-        filteredInvestCompany.every(
-          (company) => company.length <= MAX_COMPANY_LENGTH,
-        ) &&
-        !hasDuplicates &&
-        input.length <= MAX_TAGS
-      );
+  useValidator: ({ initialState, companyInputPresentation }) => {
+    const initialStateForInput = {
+      companyName: initialState?.companyName,
+      explanation: initialState?.explanation,
+      email: initialState?.email,
+      slogan: initialState?.slogan,
+      investAmount: String(initialState?.investAmount),
+      investCompany: initialState?.investCompany,
+      series: initialState?.series,
+      irDeckPreview: initialState?.irDeckPreview,
+      landingPageLink: initialState?.landingPageLink,
+      imagePreview: initialState?.imagePreview,
+      externalDescriptionLink: initialState?.externalDescriptionLink,
+      tags: initialState?.tags,
     };
 
-    const isTagsValid = (input: string[]) => {
-      const hasDuplicates = new Set(input).size !== input.length;
-      return (
-        input.every((company) => TAG_REGEX.test(company)) || !hasDuplicates
-      );
-    };
-
-    const handleCompanyNameChange = (input: string) => {
-      setCompanyName(input);
-    };
-    const handleEmailChange = (input: string) => {
-      setEmail(input);
-    };
-    const handleSloganChange = (input: string) => {
-      setSlogan(input);
-    };
-    const handleImageLinkChange = (input: string) => {
-      setImageLink(input);
-    };
-    const handleSeriesChange = (input: Series | 'NONE') => {
-      setSeries(input);
-    };
-    const handleInvestAmountChange = (input: string) => {
-      setInvestAmount(input);
-    };
-    const handleInvestCompanyChange = ({
-      input,
-      index,
-      mode,
-    }:
-      | {
-          input: string;
-          mode: 'ADD' | 'REMOVE';
-          index?: never;
-        }
-      | {
-          input: string;
-          mode: 'PATCH';
-          index: number;
-        }) => {
-      setInvestCompany((prevState) => {
-        switch (mode) {
-          case 'ADD':
-            return isInvestCompanyExist(input)
-              ? prevState
-              : [...prevState, input];
-
-          case 'REMOVE':
-            return prevState.filter((item) => item !== input);
-
-          case 'PATCH':
-            if (index < 0 || index >= prevState.length) {
-              return prevState;
-            }
-            return prevState.map((item, idx) => (idx === index ? input : item));
-
-          default:
-            return prevState;
-        }
-      });
-    };
-    const handleTagChange = (input: string) => {
-      setTag(input);
-    };
-    const handleTagsChange = ({
-      input,
-      index,
-      mode,
-    }:
-      | {
-          input: string;
-          index?: never;
-          mode: 'ADD' | 'REMOVE';
-        }
-      | {
-          input: string;
-          index: number;
-          mode: 'PATCH';
-        }) => {
-      setTags((prevState) => {
-        switch (mode) {
-          case 'ADD':
-            return [...prevState, input];
-          case 'REMOVE':
-            return prevState.filter((item) => item !== input);
-          case 'PATCH':
-            if (index < 0 || index >= prevState.length) {
-              return prevState;
-            }
-            return prevState.map((item, idx) => (idx === index ? input : item));
-          default:
-            return prevState;
-        }
-      });
-    };
-    const handleIRDeckLinkChange = (input: string) => {
-      setIRDeckLink(input);
-    };
-    const handleLandingPageLinkChange = (input: string) => {
-      setLandingPageLink(input);
-    };
-    const handleExternalDescriptionLinkChange = ({
-      input,
-      index,
-      mode,
-    }:
-      | {
-          input: ExternalLink;
-          index?: never;
-          mode: 'ADD' | 'REMOVE';
-        }
-      | {
-          input: ExternalLink;
-          index: number;
-          mode: 'PATCH';
-        }) => {
-      setExternalDescriptionLink((prevState) => {
-        switch (mode) {
-          case 'ADD':
-            return isExternalLinkExist(input)
-              ? prevState
-              : [...prevState, input];
-
-          case 'REMOVE':
-            return prevState.filter(
-              (item) =>
-                !(
-                  item.link === input.link &&
-                  item.description === input.description
-                ),
-            );
-
-          case 'PATCH':
-            if (index < 0 || index >= prevState.length) {
-              return prevState;
-            }
-            return prevState.map((item, idx) => (idx === index ? input : item));
-
-          default:
-            return prevState;
-        }
-      });
-    };
-    const handleExplanationChange = (input: string) => {
-      setExplanation(input);
-    };
+    const {
+      companyName,
+      explanation,
+      email,
+      slogan,
+      investAmount,
+      rawInvestCompany,
+      investCompany,
+      series,
+      irDeckPreview,
+      irDeckLink,
+      landingPageLink,
+      imagePreview,
+      imageLink,
+      rawExternalDescriptionLink,
+      externalDescriptionLink,
+      rawTag,
+      tags,
+    } = companyInputPresentation.useValidator({
+      initialState: initialStateForInput,
+    });
 
     return {
-      companyName: {
-        isError:
-          companyName.length > MAX_COMPANY_LENGTH || companyName.length === 0,
-        value: companyName,
-        onChange: handleCompanyNameChange,
+      inputStates: {
+        companyName,
+        explanation,
+        email,
+        slogan,
+        investAmount,
+        rawInvestCompany,
+        investCompany,
+        series,
+        irDeckPreview,
+        landingPageLink,
+        imagePreview,
+        rawExternalDescriptionLink,
+        externalDescriptionLink,
+        rawTag,
+        tags,
       },
-      explanation: {
-        isError:
-          explanation.length > MAX_EXPLANATION_LENGTH ||
-          explanation.length === 0,
-        value: explanation,
-        onChange: handleExplanationChange,
-      },
-      email: {
-        isError: !EMAIL_REGEX.test(email),
-        value: email,
-        onChange: handleEmailChange,
-      },
-      slogan: {
-        isError: slogan.length > MAX_SLOGAN_LENGTH || slogan.length === 0,
-        value: slogan,
-        onChange: handleSloganChange,
-      },
-      imageLink: {
-        isError: !URL_REGEX.test(imageLink),
-        value: imageLink,
-        onChange: handleImageLinkChange,
-      },
-      series: {
-        isError: series === 'NONE',
-        value: series,
-        onChange: handleSeriesChange,
-      },
-      investAmount: {
-        isError: isNaN(Number(investAmount)) || Number(investAmount) < 0,
-        value: investAmount,
-        onChange: handleInvestAmountChange,
-      },
-      investCompany: {
-        isError: !isInvestCompanyValid(investCompany),
-        value: investCompany,
-        onChange: handleInvestCompanyChange,
-      },
-      tag: {
-        isError: false,
-        value: tag,
-        onChange: handleTagChange,
-      },
-      tags: {
-        isError: isTagsValid(tags),
-        value: tags,
-        onChange: handleTagsChange,
-      },
-      IRDeckLink: {
-        isError: !URL_REGEX.test(IRDeckLink),
-        value: IRDeckLink,
-        onChange: handleIRDeckLinkChange,
-      },
-      landingPageLink: {
-        isError: !URL_REGEX.test(landingPageLink),
-        value: landingPageLink,
-        onChange: handleLandingPageLinkChange,
-      },
-      externalDescriptionLink: {
-        isError: !isExternalLinkValid(externalDescriptionLink),
-        value: externalDescriptionLink,
-        onChange: handleExternalDescriptionLinkChange,
+      formStates: {
+        companyName: companyName,
+        explanation: explanation,
+        email: email,
+        slogan: slogan,
+        imageLink: imageLink,
+        series: series,
+        investAmount: {
+          isError: isNaN(Number(investAmount)) || Number(investAmount) < 0,
+          value: Number(investAmount),
+        },
+        investCompany: {
+          isError: investCompany.isError,
+          value: investCompany.value.filter((item) => item.trim().length !== 0),
+        },
+        tags: tags,
+        irDeckLink: irDeckLink,
+        landingPageLink: landingPageLink,
+        externalDescriptionLink: {
+          isError: externalDescriptionLink.isError,
+          value: externalDescriptionLink.value.filter(
+            (item) =>
+              item.link.trim().length !== 0 &&
+              item.description.trim().length !== 0,
+          ),
+        },
       },
     };
-  },
-  useUtilState: () => {
-    const [rawTags, setRawTags] = useState('');
-    const [thumbnail, setThumbnail] = useState<{
-      file: File;
-      url: string;
-    } | null>(null);
-    const [IRDeckPreview, setIRDeckPreview] = useState<{
-      file: File;
-      url: string;
-    } | null>(null);
-
-    const isThumbnailImageValid = (
-      input: {
-        file: File;
-        url: string;
-      } | null,
-    ) => {
-      if (input === null) {
-        return false;
-      }
-      const fileExtenstion = input.file.name
-        .split('.')
-        .pop()
-        ?.toLocaleLowerCase();
-      if (fileExtenstion === undefined) {
-        return false;
-      }
-      if (!IMAGE_EXTENSIONS.includes(fileExtenstion)) {
-        return false;
-      }
-      if (input.file.size > MAX_IMAGE_SIZE) {
-        return false;
-      }
-      return true;
-    };
-    const isIRDeckPreviewValid = (
-      input: {
-        file: File;
-        url: string;
-      } | null,
-    ) => {
-      if (input === null) {
-        return false;
-      }
-
-      const fileExtenstion = input.file.name
-        .split('.')
-        .pop()
-        ?.toLocaleLowerCase();
-      if (fileExtenstion === undefined) {
-        return false;
-      }
-      if (!FILE_EXTENSIONS.includes(fileExtenstion)) {
-        return false;
-      }
-      if (input.file.size > MAX_FILE_SIZE) {
-        return false;
-      }
-      return true;
-    };
-
-    const handleThumbnailChange = (
-      input: {
-        file: File;
-        url: string;
-      } | null,
-    ) => {
-      setThumbnail(input);
-    };
-    const handleIRDeckPreview = (input: { file: File; url: string } | null) => {
-      setIRDeckPreview(input);
-    };
-    const handleRawTags = (input: string) => {
-      setRawTags(input);
-    };
-
-    return {
-      rawTags: {
-        isError: false,
-        value: rawTags,
-        onChange: handleRawTags,
-      },
-      thumbnail: {
-        isError: !isThumbnailImageValid(thumbnail),
-        value: thumbnail,
-        onChange: handleThumbnailChange,
-      },
-      IRDeckPreview: {
-        isError: !isIRDeckPreviewValid(IRDeckPreview),
-        value: IRDeckPreview,
-        onChange: handleIRDeckPreview,
-      },
-    };
-  },
-  validator: {
-    tagValidator: ({ tag, tags }: { tag: string; tags: string[] }) => {
-      if (tags.includes(tag)) {
-        return false;
-      }
-      if (tag.length > MAX_TAG_LENGTH || tag.length === 0) {
-        return false;
-      }
-      return true;
-    },
-    tagInputValidator: ({ tag, tags }: { tag: string; tags: string[] }) => {
-      return !(tags.includes(tag) || tag.length > MAX_TAG_LENGTH);
-    },
-  },
-  filter: {
-    tagsFilter: (tags: string[]) => {
-      const filteredTags = tags.filter((item) => item.trim().length !== 0);
-      return Array.from(new Set(filteredTags));
-    },
-    investCompanyFilter: (tags: string[]) => {
-      const filteredTags = tags.filter((item) => item.trim().length !== 0);
-      return Array.from(new Set(filteredTags));
-    },
-    externalDescriptionLinkFilter: (tags: ExternalLink[]) => {
-      const filteredTags = tags.filter(
-        (item) =>
-          item.link.trim().length !== 0 && item.description.trim().length !== 0,
-      );
-      return Array.from(new Set(filteredTags));
-    },
   },
 };

--- a/apps/client/src/feature/company/presentation/companyFormPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyFormPresentation.ts
@@ -115,6 +115,11 @@ export const companyFormPresentation: CompanyFormPresentation = {
       initialState: initialStateForInput,
     });
 
+    const isEmptyElementsInFilteredStringList = (input: string[]) => {
+      const filteredInput = input.filter((item) => item.trim().length !== 0);
+      return filteredInput.length === 0;
+    };
+
     return {
       inputStates: {
         companyName,
@@ -165,7 +170,9 @@ export const companyFormPresentation: CompanyFormPresentation = {
           value: Number(investAmount),
         },
         investCompany: {
-          isError: investCompany.isError || investCompany.value.length === 0,
+          isError:
+            investCompany.isError ||
+            isEmptyElementsInFilteredStringList(investCompany.value),
           value: investCompany.value
             .filter((item) => item.trim().length !== 0)
             .join(','),

--- a/apps/client/src/feature/company/presentation/companyInputPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyInputPresentation.ts
@@ -148,11 +148,9 @@ export const companyInputPresentation: CompanyInputPresentation = {
       if (trimmedInput.length > MAX_RAW_INVEST_COMPANY_LENGTH) {
         return false;
       }
-
       const filteredInvestCompanies = investCompany.filter(
         (company) => company.trim() !== trimmedInput,
       );
-
       // 공백인 input이 여러개 발생할 수 있도록 설정
       if (
         trimmedInput.length !== 0 &&
@@ -246,6 +244,9 @@ export const companyInputPresentation: CompanyInputPresentation = {
       } | null,
     ) => {
       if (input === null) {
+        return true;
+      }
+      if (!input.file.type.startsWith('application/pdf')) {
         return false;
       }
 
@@ -271,6 +272,9 @@ export const companyInputPresentation: CompanyInputPresentation = {
       } | null,
     ) => {
       if (input === null) {
+        return true;
+      }
+      if (!input.file.type.startsWith('image/')) {
         return false;
       }
 
@@ -311,19 +315,16 @@ export const companyInputPresentation: CompanyInputPresentation = {
             return isRawInvestCompanyValid(input)
               ? [...prevState, input]
               : prevState;
-
           case 'REMOVE':
             return [
               ...prevState.slice(0, index),
               ...prevState.slice(index + 1),
             ];
-
           case 'PATCH':
             if (index < 0 || index >= prevState.length) {
               return prevState;
             }
             return prevState.map((item, idx) => (idx === index ? input : item));
-
           default:
             return prevState;
         }
@@ -350,19 +351,16 @@ export const companyInputPresentation: CompanyInputPresentation = {
             return isRawExternalDescriptionLinkValid(input)
               ? [...prevState, input]
               : prevState;
-
           case 'REMOVE':
             return [
               ...prevState.slice(0, index),
               ...prevState.slice(index + 1),
             ];
-
           case 'PATCH':
             if (index < 0 || index >= prevState.length) {
               return prevState;
             }
             return prevState.map((item, idx) => (idx === index ? input : item));
-
           default:
             return prevState;
         }
@@ -415,7 +413,7 @@ export const companyInputPresentation: CompanyInputPresentation = {
         onChange: setExplanation,
       },
       email: {
-        isError: !EMAIL_REGEX.test(email),
+        isError: email.trim().length !== 0 && !EMAIL_REGEX.test(email),
         value: email,
         onChange: setEmail,
       },
@@ -450,12 +448,14 @@ export const companyInputPresentation: CompanyInputPresentation = {
         onChange: setIrDeckPreview,
       },
       irDeckLink: {
-        isError: irDeckLink.trim().length === 0,
+        isError: false,
         value: irDeckLink,
         onChange: setIrDeckLink,
       },
       landingPageLink: {
-        isError: !URL_REGEX.test(landingPageLink),
+        isError:
+          landingPageLink.trim().length !== 0 &&
+          !URL_REGEX.test(landingPageLink),
         value: landingPageLink,
         onChange: setLandingPageLink,
       },

--- a/apps/client/src/feature/company/presentation/companyInputPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyInputPresentation.ts
@@ -1,0 +1,448 @@
+import { useState } from 'react';
+
+import type { Input, ListInput, SelectInput } from '@/entities/input';
+import type { Series } from '@/entities/post';
+
+type ExternalLink = {
+  link: string;
+  description: string;
+};
+
+type InitialInputState = {
+  companyName: string;
+  explanation: string;
+  email: string;
+  slogan: string;
+  investAmount: string;
+  rawInvestCompany: string;
+  investCompany: string[];
+  series: Series | 'NONE';
+  irDeckPreview: { file: File; url: string } | null;
+  landingPageLink: string;
+  imagePreview: { file: File; url: string } | null;
+  rawExternalDescriptionLink: ExternalLink;
+  externalDescriptionLink: ExternalLink[];
+  rawTag: string;
+  tags: string[];
+};
+
+export type CompanyInputPresentation = {
+  useValidator({ initialState }: { initialState?: InitialInputState }): {
+    companyName: Input<string>;
+    explanation: Input<string>;
+    email: Input<string>;
+    slogan: Input<string>;
+    investAmount: Input<string>;
+    rawInvestCompany: Input<string>;
+    investCompany: ListInput<string>;
+    series: SelectInput<Series | 'NONE'>;
+    irDeckPreview: Input<{ file: File; url: string } | null>;
+    landingPageLink: Input<string>;
+    imagePreview: Input<{ file: File; url: string } | null>;
+    rawExternalDescriptionLink: Input<ExternalLink>;
+    externalDescriptionLink: ListInput<ExternalLink>;
+    rawTag: Input<string>;
+    tags: ListInput<string>;
+  };
+};
+
+const MAX_COMPANY_NAME_LENGTH = 30;
+const MAX_EXPLANATION_LENGTH = 5000;
+const MAX_SLOGAN_LENGTH = 100;
+const MAX_RAW_INVEST_COMPANY_LENGTH = 100;
+const MAX_DESCRIPTION_LENGTH = 30;
+const MAX_TAG_LENGTH = 8;
+const MAX_INVEST_COMPANY_SIZE = 10;
+const MAX_EXTERNAL_DESCRIPTION_LINK_SIZE = 5;
+const MAX_TAGS_SIZE = 10;
+
+const MAX_FILE_SIZE = 5 * 1024 * 2024;
+const MAX_IMAGE_SIZE = 1 * 1024 * 1024;
+
+const FILE_EXTENSIONS = ['pdf'];
+const IMAGE_EXTENSIONS = [
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'svg',
+  'tiff',
+  'ico',
+  'heif',
+  'heic',
+];
+
+const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const INVEST_AMOUNT_REGEX = /^\s*$|^[0-9]+$/;
+const URL_REGEX = /^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$/;
+
+export const companyInputPresentation: CompanyInputPresentation = {
+  useValidator: ({ initialState }) => {
+    const [companyName, setCompanyName] = useState(
+      initialState?.companyName !== undefined ? initialState.companyName : '',
+    );
+    const [explanation, setExplanation] = useState(
+      initialState?.explanation !== undefined ? initialState.explanation : '',
+    );
+    const [email, setEmail] = useState(
+      initialState?.email !== undefined ? initialState.email : '',
+    );
+    const [slogan, setSlogan] = useState(
+      initialState?.slogan !== undefined ? initialState.slogan : '',
+    );
+    const [investAmount, setInvestAmount] = useState(
+      initialState?.investAmount !== undefined ? initialState.investAmount : '',
+    );
+    const [rawInvestCompany, setRawInvestCompany] = useState(
+      initialState?.rawInvestCompany !== undefined
+        ? initialState.rawInvestCompany
+        : '',
+    );
+    const [investCompany, setInvestCompany] = useState<string[]>(
+      initialState?.investCompany !== undefined
+        ? initialState.investCompany
+        : [''],
+    );
+    const [series, setSeries] = useState<Series | 'NONE'>(
+      initialState?.series !== undefined ? initialState.series : 'NONE',
+    );
+    const [irDeckPreview, setIrDeckPreview] = useState(
+      initialState?.irDeckPreview !== undefined
+        ? initialState.irDeckPreview
+        : null,
+    );
+    const [landingPageLink, setLandingPageLink] = useState(
+      initialState?.landingPageLink !== undefined
+        ? initialState.landingPageLink
+        : '',
+    );
+    const [imagePreview, setImagePreview] = useState<{
+      file: File;
+      url: string;
+    } | null>(
+      initialState?.imagePreview !== undefined
+        ? initialState.imagePreview
+        : null,
+    );
+    const [rawExternalDescriptionLink, setRawExternalDescriptionLink] =
+      useState<ExternalLink>(
+        initialState?.rawExternalDescriptionLink !== undefined
+          ? initialState.rawExternalDescriptionLink
+          : { link: '', description: '' },
+      );
+    const [externalDescriptionLink, setExternalDescriptionLink] = useState<
+      ExternalLink[]
+    >(
+      initialState?.externalDescriptionLink !== undefined
+        ? initialState.externalDescriptionLink
+        : [{ link: '', description: '' }],
+    );
+    const [rawTag, setRawTag] = useState(
+      initialState?.rawTag !== undefined ? initialState.rawTag : '',
+    );
+    const [tags, setTags] = useState<string[]>(
+      initialState?.tags !== undefined ? initialState.tags : [],
+    );
+
+    const isRawInvestCompanyValid = (input: string) => {
+      const trimmedInput = input.trim();
+      if (
+        trimmedInput.length === 0 ||
+        trimmedInput.length > MAX_RAW_INVEST_COMPANY_LENGTH
+      ) {
+        return false;
+      }
+      if (investCompany.includes(trimmedInput)) {
+        return false;
+      }
+      return true;
+    };
+    const isInvestCompanyValid = (input: string[]) => {
+      if (input.length > MAX_INVEST_COMPANY_SIZE) {
+        return false;
+      }
+      return true;
+    };
+    const isRawExternalDescriptionLinkValid = (input: ExternalLink) => {
+      if (
+        input.description.trim().length === 0 ||
+        input.description.trim().length > MAX_DESCRIPTION_LENGTH
+      ) {
+        return false;
+      }
+      if (!URL_REGEX.test(input.link)) {
+        return false;
+      }
+      if (
+        externalDescriptionLink.some(
+          (item) =>
+            item.link === input.link && item.description === input.description,
+        )
+      ) {
+        return false;
+      }
+      return true;
+    };
+    const isExternalLinkValid = (input: ExternalLink[]) => {
+      if (input.length > MAX_EXTERNAL_DESCRIPTION_LINK_SIZE) {
+        return false;
+      }
+      return true;
+    };
+    const isRawTagValid = (input: string) => {
+      if (input.trim().length === 0 || input.trim().length > MAX_TAG_LENGTH) {
+        return false;
+      }
+      if (tags.includes(input)) {
+        return false;
+      }
+      return true;
+    };
+    const isTagsValid = (input: string[]) => {
+      if (input.length > MAX_TAGS_SIZE) {
+        return false;
+      }
+      return true;
+    };
+    const isIrDeckPreviewValid = (
+      input: {
+        file: File;
+        url: string;
+      } | null,
+    ) => {
+      if (input === null) {
+        return false;
+      }
+
+      const fileExtenstion = input.file.name
+        .split('.')
+        .pop()
+        ?.toLocaleLowerCase();
+      if (fileExtenstion === undefined) {
+        return false;
+      }
+      if (!FILE_EXTENSIONS.includes(fileExtenstion)) {
+        return false;
+      }
+      if (input.file.size > MAX_FILE_SIZE) {
+        return false;
+      }
+      return true;
+    };
+    const isImagePreviewValid = (
+      input: {
+        file: File;
+        url: string;
+      } | null,
+    ) => {
+      if (input === null) {
+        return false;
+      }
+
+      const fileExtenstion = input.file.name
+        .split('.')
+        .pop()
+        ?.toLocaleLowerCase();
+      if (fileExtenstion === undefined) {
+        return false;
+      }
+      if (!IMAGE_EXTENSIONS.includes(fileExtenstion)) {
+        return false;
+      }
+      if (input.file.size > MAX_IMAGE_SIZE) {
+        return false;
+      }
+      return true;
+    };
+
+    const handleInvestCompanyChange = ({
+      input,
+      index,
+      mode,
+    }:
+      | {
+          input: string;
+          mode: 'ADD' | 'REMOVE';
+          index?: never;
+        }
+      | {
+          input: string;
+          mode: 'PATCH';
+          index: number;
+        }) => {
+      setInvestCompany((prevState) => {
+        switch (mode) {
+          case 'ADD':
+            return isRawInvestCompanyValid(input)
+              ? prevState
+              : [...prevState, input];
+
+          case 'REMOVE':
+            return prevState.filter((item) => item !== input);
+
+          case 'PATCH':
+            if (index < 0 || index >= prevState.length) {
+              return prevState;
+            }
+            return prevState.map((item, idx) => (idx === index ? input : item));
+
+          default:
+            return prevState;
+        }
+      });
+    };
+    const handleExternalDescriptionLinkChange = ({
+      input,
+      index,
+      mode,
+    }:
+      | {
+          input: ExternalLink;
+          index?: never;
+          mode: 'ADD' | 'REMOVE';
+        }
+      | {
+          input: ExternalLink;
+          index: number;
+          mode: 'PATCH';
+        }) => {
+      setExternalDescriptionLink((prevState) => {
+        switch (mode) {
+          case 'ADD':
+            return isRawExternalDescriptionLinkValid(input)
+              ? prevState
+              : [...prevState, input];
+
+          case 'REMOVE':
+            return prevState.filter(
+              (item) =>
+                !(
+                  item.link === input.link &&
+                  item.description === input.description
+                ),
+            );
+
+          case 'PATCH':
+            if (index < 0 || index >= prevState.length) {
+              return prevState;
+            }
+            return prevState.map((item, idx) => (idx === index ? input : item));
+
+          default:
+            return prevState;
+        }
+      });
+    };
+    const handleTagsChange = ({
+      input,
+      index,
+      mode,
+    }:
+      | {
+          input: string;
+          index?: never;
+          mode: 'ADD' | 'REMOVE';
+        }
+      | {
+          input: string;
+          index: number;
+          mode: 'PATCH';
+        }) => {
+      setTags((prevState) => {
+        switch (mode) {
+          case 'ADD':
+            return [...prevState, input];
+          case 'REMOVE':
+            return prevState.filter((item) => item !== input);
+          case 'PATCH':
+            if (index < 0 || index >= prevState.length) {
+              return prevState;
+            }
+            return prevState.map((item, idx) => (idx === index ? input : item));
+          default:
+            return prevState;
+        }
+      });
+    };
+
+    return {
+      companyName: {
+        isError: companyName.length > MAX_COMPANY_NAME_LENGTH,
+        value: companyName,
+        onChange: setCompanyName,
+      },
+      explanation: {
+        isError: explanation.length > MAX_EXPLANATION_LENGTH,
+        value: explanation,
+        onChange: setExplanation,
+      },
+      email: {
+        isError: !EMAIL_REGEX.test(email),
+        value: email,
+        onChange: setEmail,
+      },
+      slogan: {
+        isError: slogan.length > MAX_SLOGAN_LENGTH,
+        value: slogan,
+        onChange: setSlogan,
+      },
+      investAmount: {
+        isError: !INVEST_AMOUNT_REGEX.test(investAmount),
+        value: investAmount,
+        onChange: setInvestAmount,
+      },
+      rawInvestCompany: {
+        isError: !isRawInvestCompanyValid(rawInvestCompany),
+        value: rawInvestCompany,
+        onChange: setRawInvestCompany,
+      },
+      investCompany: {
+        isError: !isInvestCompanyValid(investCompany),
+        value: investCompany,
+        onChange: handleInvestCompanyChange,
+      },
+      series: {
+        isError: series === 'NONE',
+        value: series,
+        onChange: setSeries,
+      },
+      irDeckPreview: {
+        isError: !isIrDeckPreviewValid(irDeckPreview),
+        value: irDeckPreview,
+        onChange: setIrDeckPreview,
+      },
+      landingPageLink: {
+        isError: !URL_REGEX.test(landingPageLink),
+        value: landingPageLink,
+        onChange: setLandingPageLink,
+      },
+      imagePreview: {
+        isError: !isImagePreviewValid(imagePreview),
+        value: imagePreview,
+        onChange: setImagePreview,
+      },
+      rawExternalDescriptionLink: {
+        isError: !isRawExternalDescriptionLinkValid(rawExternalDescriptionLink),
+        value: rawExternalDescriptionLink,
+        onChange: setRawExternalDescriptionLink,
+      },
+      externalDescriptionLink: {
+        isError: !isExternalLinkValid(externalDescriptionLink),
+        value: externalDescriptionLink,
+        onChange: handleExternalDescriptionLinkChange,
+      },
+      rawTag: {
+        isError: !isRawTagValid(rawTag),
+        value: rawTag,
+        onChange: setRawTag,
+      },
+      tags: {
+        isError: !isTagsValid(tags),
+        value: tags,
+        onChange: handleTagsChange,
+      },
+    };
+  },
+};

--- a/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
+++ b/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
@@ -13,11 +13,8 @@ import { Button } from '@/components/ui/button';
 import { createErrorMessage } from '@/entities/errors';
 import type { Series, seriesList } from '@/entities/post';
 import type { CreateCompanyRequest } from '@/entities/post';
-import {
-  MAX_EXPLANATION_LENGTH,
-  MAX_SLOGAN_LENGTH,
-} from '@/feature/company/presentation/companyInputPresentation';
-import { companyPresentation } from '@/feature/company/presentation/companyInputPresentation';
+import { companyFormPresentation } from '@/feature/company/presentation/companyFormPresentation';
+import { companyInputPresentation } from '@/feature/company/presentation/companyInputPresentation';
 import { ExternalLinkField } from '@/feature/company/ui/fields/ExternalLinkField';
 import { HashtagField } from '@/feature/company/ui/fields/HashtagField';
 import { InvestAmountField } from '@/feature/company/ui/fields/InvestAmountField';
@@ -34,22 +31,26 @@ export const CreateCompanyForm = () => {
   const [imageResponseMessage, setImageResponseMessage] = useState('');
   const [pdfResponseMessage, setPdfResponseMessage] = useState('');
 
+  const { inputStates, formStates } = companyFormPresentation.useValidator({
+    companyInputPresentation,
+  });
   const {
     companyName,
+    explanation,
     email,
     slogan,
-    tags,
-    series,
     investAmount,
+    rawInvestCompany,
     investCompany,
+    series,
+    irDeckPreview,
     landingPageLink,
+    imagePreview,
+    rawExternalDescriptionLink,
     externalDescriptionLink,
-    explanation,
-  } = companyPresentation.useValidator({});
-  const { rawTags, thumbnail, IRDeckPreview } =
-    companyPresentation.useUtilState();
-  const { tagsFilter, investCompanyFilter, externalDescriptionLinkFilter } =
-    companyPresentation.filter;
+    rawTag,
+    tags,
+  } = inputStates;
   const { toMain } = useRouteNavigation();
 
   const handleClickCancelButton = () => {

--- a/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
+++ b/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
@@ -60,7 +60,6 @@ export const CreateCompanyForm = () => {
     tags,
   } = inputStates;
 
-  console.log(rawExternalDescriptionLink, externalDescriptionLink);
   const { toMain } = useRouteNavigation();
 
   const handleClickCancelButton = () => {
@@ -178,6 +177,7 @@ export const CreateCompanyForm = () => {
           input={companyName}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.companyName.isError}
           placeholder="회사명을 입력해주세요."
           errorMessage="올바른 회사명을 입력해주세요."
           required={true}
@@ -187,6 +187,7 @@ export const CreateCompanyForm = () => {
           input={email}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.email.isError}
           placeholder="회사 이메일을 입력해주세요."
           errorMessage="올바르지 않은 이메일 형식입니다."
           required={true}
@@ -196,6 +197,7 @@ export const CreateCompanyForm = () => {
           input={slogan}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.slogan.isError}
           maxLength={MAX_SLOGAN_LENGTH}
           errorMessage={`한 줄 소개는 ${MAX_SLOGAN_LENGTH}자 이내로 작성해주세요.`}
           infoMessage="한 줄 소개는 공고 카드에 보여져요."
@@ -206,6 +208,7 @@ export const CreateCompanyForm = () => {
           input={explanation}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.explanation.isError}
           maxLength={MAX_EXPLANATION_LENGTH}
           errorMessage={`상세 소개는 ${MAX_EXPLANATION_LENGTH}자 이내로 작성해주세요.`}
           infoMessage="상세 소개는 공고 글에 보여져요."
@@ -216,6 +219,7 @@ export const CreateCompanyForm = () => {
           input={imagePreview}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.imageLink.isError}
           errorMessage="1MB 이하의 이미지 파일을 올려주세요."
           responseErrorMessage={imageResponseMessage}
           infoMessage="회사 썸네일 이미지는 정사각형 비율(1:1)로 보여져요."
@@ -227,6 +231,7 @@ export const CreateCompanyForm = () => {
           inputList={seriesList}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.series.isError}
           errorMessage="투자 단계를 선택해주세요."
           required={true}
         />
@@ -236,6 +241,7 @@ export const CreateCompanyForm = () => {
           unit="천만원"
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.investAmount.isError}
           errorMessage="0 이상의 양의 정수로 입력해주세요."
           required={true}
         />
@@ -245,6 +251,7 @@ export const CreateCompanyForm = () => {
           rawInput={rawInvestCompany}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.investCompany.isError}
           placeholder="투자사 이름을 입력해주세요."
           errorMessage="투자사 정보는 1개 이상, 10개 이하로 중복되지 않게 입력해주세요."
           inputErrorMessage="중복되지 않는 100자 이내의 투자사 이름을 작성해주세요."
@@ -256,6 +263,7 @@ export const CreateCompanyForm = () => {
           rawInput={rawTag}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.tags.isError}
           placeholder="회사를 소개하는 태그를 입력해주세요. (최대 10개)"
           infoMessage="엔터를 치면 태그가 생성되며 한 개당 최대 8자까지 입력할 수 있어요."
           inputErrorMessage="입력한 태그와 중복되지 않는 8자 이하의 태그를 작성해주세요."
@@ -266,15 +274,16 @@ export const CreateCompanyForm = () => {
           input={irDeckPreview}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.irDeckLink.isError}
           errorMessage="5MB 이하의 PDF 파일을 올려주세요."
           responseErrorMessage={pdfResponseMessage}
-          required={true}
         />
         <StringField
           label="기업 소개 홈페이지"
           input={landingPageLink}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.landingPageLink.isError}
           placeholder="https://"
           errorMessage="https로 시작하는 홈페이지 링크를 입력해주세요."
         />
@@ -288,6 +297,7 @@ export const CreateCompanyForm = () => {
           rawInput={rawExternalDescriptionLink}
           isPending={isPending}
           isSubmit={isSubmit}
+          isSubmitError={formStates.externalDescriptionLink.isError}
           placeholder={{
             description:
               '링크 제목을 작성해주세요. (e.g. OO 프로젝트 성과 기사)',

--- a/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
+++ b/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
@@ -11,14 +11,13 @@ import { FormContainer } from '@/components/form';
 import { CancelCheckModal } from '@/components/modal/CancelCheckModal';
 import { Button } from '@/components/ui/button';
 import { createErrorMessage } from '@/entities/errors';
-import type { Series } from '@/entities/post';
+import type { Series, seriesList } from '@/entities/post';
 import type { CreateCompanyRequest } from '@/entities/post';
 import {
   MAX_EXPLANATION_LENGTH,
   MAX_SLOGAN_LENGTH,
-  seriesList,
-} from '@/feature/company/presentation/companyPresentation';
-import { companyPresentation } from '@/feature/company/presentation/companyPresentation';
+} from '@/feature/company/presentation/companyInputPresentation';
+import { companyPresentation } from '@/feature/company/presentation/companyInputPresentation';
 import { ExternalLinkField } from '@/feature/company/ui/fields/ExternalLinkField';
 import { HashtagField } from '@/feature/company/ui/fields/HashtagField';
 import { InvestAmountField } from '@/feature/company/ui/fields/InvestAmountField';
@@ -100,7 +99,6 @@ export const CreateCompanyForm = () => {
 
   const handleSubmit = () => {
     setIsSubmit(true);
-    console.log(series);
     if (thumbnail.value !== null) {
       uploadImage({
         fileName: thumbnail.value.file.name,

--- a/apps/client/src/feature/company/ui/fields/ExternalLinkField.tsx
+++ b/apps/client/src/feature/company/ui/fields/ExternalLinkField.tsx
@@ -23,6 +23,7 @@ type ExternalLinkFieldProps = {
   }>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   inputErrorMessage: string;
   infoMessage?: string;
@@ -39,6 +40,7 @@ export const ExternalLinkField = ({
   rawInput,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   inputErrorMessage,
   infoMessage,
@@ -120,7 +122,7 @@ export const ExternalLinkField = ({
         {rawInput.isError && (
           <FormErrorResponse>{inputErrorMessage}</FormErrorResponse>
         )}
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>

--- a/apps/client/src/feature/company/ui/fields/ExternalLinkField.tsx
+++ b/apps/client/src/feature/company/ui/fields/ExternalLinkField.tsx
@@ -5,9 +5,9 @@ import {
 } from '@/components/response/formResponse';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import type { ListInput } from '@/entities/input';
+import type { Input as InputType, ListInput } from '@/entities/input';
 
-type HashtagFieldProps = {
+type ExternalLinkFieldProps = {
   label: {
     main: string;
     link: string;
@@ -17,9 +17,14 @@ type HashtagFieldProps = {
     link: string;
     description: string;
   }>;
+  rawInput: InputType<{
+    link: string;
+    description: string;
+  }>;
   isPending: boolean;
   isSubmit: boolean;
   errorMessage: string;
+  inputErrorMessage: string;
   infoMessage?: string;
   required?: boolean;
   placeholder?: {
@@ -31,18 +36,20 @@ type HashtagFieldProps = {
 export const ExternalLinkField = ({
   label,
   input,
+  rawInput,
   isPending,
   isSubmit,
   errorMessage,
+  inputErrorMessage,
   infoMessage,
   required,
   placeholder,
-}: HashtagFieldProps) => {
+}: ExternalLinkFieldProps) => {
   return (
     <LabelContainer label={label.main} required={required}>
       {input.value.map((item, index) => (
         <div key={`external-link-${index}`}>
-          <div>
+          <div className="flex flex-col gap-2">
             <LabelContainer label={label.description}>
               <Input
                 value={item.description}
@@ -56,6 +63,10 @@ export const ExternalLinkField = ({
                     },
                     index,
                     mode: 'PATCH',
+                  });
+                  rawInput.onChange({
+                    link: item.link,
+                    description: e.target.value,
                   });
                 }}
               />
@@ -74,6 +85,10 @@ export const ExternalLinkField = ({
                     index,
                     mode: 'PATCH',
                   });
+                  rawInput.onChange({
+                    link: e.target.value,
+                    description: item.description,
+                  });
                 }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
@@ -90,7 +105,7 @@ export const ExternalLinkField = ({
               disabled={isPending}
               onClick={(e) => {
                 e.preventDefault();
-                input.onChange({ input: item, mode: 'REMOVE' });
+                input.onChange({ input: item, index, mode: 'REMOVE' });
               }}
             >
               삭제
@@ -101,6 +116,9 @@ export const ExternalLinkField = ({
       <div className="flex flex-col gap-1">
         {infoMessage !== undefined && (
           <FormInfoResponse>{infoMessage}</FormInfoResponse>
+        )}
+        {rawInput.isError && (
+          <FormErrorResponse>{inputErrorMessage}</FormErrorResponse>
         )}
         {isSubmit && input.isError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>

--- a/apps/client/src/feature/company/ui/fields/HashtagField.tsx
+++ b/apps/client/src/feature/company/ui/fields/HashtagField.tsx
@@ -13,6 +13,7 @@ type HashtagFieldProps = {
   rawInput: InputType<string>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   inputErrorMessage?: string;
   infoMessage?: string;
@@ -26,6 +27,7 @@ export const HashtagField = ({
   rawInput,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   inputErrorMessage,
   infoMessage,
@@ -99,7 +101,7 @@ export const HashtagField = ({
             tag: rawInput.value.trim(),
             tags: input.value,
           }) && <FormErrorResponse>{inputErrorMessage}</FormErrorResponse>}
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>

--- a/apps/client/src/feature/company/ui/fields/HashtagField.tsx
+++ b/apps/client/src/feature/company/ui/fields/HashtagField.tsx
@@ -57,14 +57,14 @@ export const HashtagField = ({
 
   return (
     <LabelContainer label={label} required={required}>
-      {input.value.map((tag) => (
+      {input.value.map((tag, index) => (
         <div key={`tag-${tag}`}>
           <span>{tag}</span>
           <Button
             disabled={isPending}
             onClick={(e) => {
               e.preventDefault();
-              input.onChange({ input: tag, mode: 'REMOVE' });
+              input.onChange({ input: tag, index, mode: 'REMOVE' });
             }}
           >
             삭제

--- a/apps/client/src/feature/company/ui/fields/InvestAmountField.tsx
+++ b/apps/client/src/feature/company/ui/fields/InvestAmountField.tsx
@@ -12,6 +12,7 @@ type InvestAmountFieldProps = {
   unit: string;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   infoMessage?: string;
   required?: boolean;
@@ -23,6 +24,7 @@ export const InvestAmountField = ({
   unit,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   infoMessage,
   required,
@@ -46,7 +48,7 @@ export const InvestAmountField = ({
         {infoMessage !== undefined && (
           <FormInfoResponse>{infoMessage}</FormInfoResponse>
         )}
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>

--- a/apps/client/src/feature/company/ui/fields/InvestCompanyField.tsx
+++ b/apps/client/src/feature/company/ui/fields/InvestCompanyField.tsx
@@ -5,14 +5,16 @@ import {
 } from '@/components/response/formResponse';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import type { ListInput } from '@/entities/input';
+import type { Input as InputType, ListInput } from '@/entities/input';
 
 type InvestCompanyFieldProps = {
   label: string;
   input: ListInput<string>;
+  rawInput: InputType<string>;
   isPending: boolean;
   isSubmit: boolean;
   errorMessage: string;
+  inputErrorMessage: string;
   infoMessage?: string;
   required?: boolean;
   placeholder?: string;
@@ -21,9 +23,11 @@ type InvestCompanyFieldProps = {
 export const InvestCompanyField = ({
   label,
   input,
+  rawInput,
   isPending,
   isSubmit,
   errorMessage,
+  inputErrorMessage,
   infoMessage,
   required,
   placeholder,
@@ -42,6 +46,7 @@ export const InvestCompanyField = ({
                 index,
                 mode: 'PATCH',
               });
+              rawInput.onChange(e.target.value);
             }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
@@ -55,7 +60,7 @@ export const InvestCompanyField = ({
             disabled={isPending}
             onClick={(e) => {
               e.preventDefault();
-              input.onChange({ input: company, mode: 'REMOVE' });
+              input.onChange({ input: company, index, mode: 'REMOVE' });
             }}
           >
             삭제
@@ -75,6 +80,9 @@ export const InvestCompanyField = ({
       <div className="flex flex-col gap-1">
         {infoMessage !== undefined && (
           <FormInfoResponse>{infoMessage}</FormInfoResponse>
+        )}
+        {rawInput.isError && (
+          <FormErrorResponse>{inputErrorMessage}</FormErrorResponse>
         )}
         {isSubmit && input.isError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>

--- a/apps/client/src/feature/company/ui/fields/InvestCompanyField.tsx
+++ b/apps/client/src/feature/company/ui/fields/InvestCompanyField.tsx
@@ -13,6 +13,7 @@ type InvestCompanyFieldProps = {
   rawInput: InputType<string>;
   isPending: boolean;
   isSubmit: boolean;
+  isSubmitError: boolean;
   errorMessage: string;
   inputErrorMessage: string;
   infoMessage?: string;
@@ -26,6 +27,7 @@ export const InvestCompanyField = ({
   rawInput,
   isPending,
   isSubmit,
+  isSubmitError,
   errorMessage,
   inputErrorMessage,
   infoMessage,
@@ -84,7 +86,7 @@ export const InvestCompanyField = ({
         {rawInput.isError && (
           <FormErrorResponse>{inputErrorMessage}</FormErrorResponse>
         )}
-        {isSubmit && input.isError && (
+        {isSubmit && isSubmitError && (
           <FormErrorResponse>{errorMessage}</FormErrorResponse>
         )}
       </div>


### PR DESCRIPTION
### 📝 작업 내용

- input과 form의 상태를 presentation 계층에서 함께 관리합니다.
- input state는 입력 가능한 상태 (공백 등 허용), form state는 제출 가능한 상태 (필수 입력 여부에 따른 공백 미허용)를 의미합니다. form state는 input state로부터 가공되며 단독으로 변경이 불가능합니다.
- input presentation 레이어를 form presentation 레이어에 주입하여 사용합니다.

- 필수 입력이 아닌 경우, 아무것도 입력되지 않았다면 에러가 나타나지 않으며 입력 시 에러가 나타나도록 설정하였습니다.
- 다중 input에서 중복된 값 또는 무효값 입력 시 제출하지 않아도 에러를 확인할 수 있도록 설정하였습니다.

- 삭제 시 item을 기준으로 한 filter가 아닌 index를 기준으로 삭제합니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
