### PR TITLE
🐛 공고 불러올 때 토큰 들어가지 않는 문제 해결 및 landingpageLink에 빈 문자열이 들어오면 undefined로 요청 보내기

### DIFF
--- a/apps/client/src/feature/company/presentation/companyFormPresentation.ts
+++ b/apps/client/src/feature/company/presentation/companyFormPresentation.ts
@@ -173,7 +173,13 @@ export const companyFormPresentation: CompanyFormPresentation = {
               ? tags.value.map((item) => ({ tag: item }))
               : undefined,
         },
-        landingPageLink: landingPageLink,
+        landingPageLink: {
+          isError: landingPageLink.isError,
+          value:
+            landingPageLink.value.trim().length !== 0
+              ? landingPageLink.value
+              : undefined,
+        },
         externalDescriptionLink: {
           isError: externalDescriptionLink.isError,
           value:

--- a/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
+++ b/apps/client/src/feature/company/ui/CreateCompanyForm.tsx
@@ -108,7 +108,7 @@ export const CreateCompanyForm = () => {
         investAmount: formStates.investAmount.value,
         investCompany: formStates.investCompany.value,
         series: formStates.series.value,
-        landingPageLink: landingPageLink.value,
+        landingPageLink: formStates.landingPageLink.value,
         externalDescriptionLink: formStates.externalDescriptionLink.value,
         tags: formStates.tags.value,
       },
@@ -443,7 +443,8 @@ const useCreateCompanyWithUploads = ({
           imageLink: imagePresignedUrlResponse.data.presignedUrl,
         },
       });
-    } catch {
+    } catch (error) {
+      console.error(error);
       setResponseMessage('업로드 과정에서 오류가 발생했습니다.');
     } finally {
       setIsPending(false);

--- a/apps/client/src/feature/post/service/postService.ts
+++ b/apps/client/src/feature/post/service/postService.ts
@@ -36,7 +36,7 @@ export type PostService = {
     token,
   }: {
     postId: string;
-    token: string;
+    token?: string;
   }): ServiceResponse<Post>;
   createCompany({
     token,
@@ -111,7 +111,10 @@ export const implPostService = ({ apis }: { apis: Apis }): PostService => ({
     const params = {
       postPath: postPath.toString(),
     };
-    const { status, data } = await apis['GET /post']({ params, token: token !== null ? token: undefined});
+    const { status, data } = await apis['GET /post']({
+      params,
+      token: token !== null ? token : undefined,
+    });
 
     if (status === 200) {
       return {
@@ -121,13 +124,7 @@ export const implPostService = ({ apis }: { apis: Apis }): PostService => ({
     }
     return { type: 'error', code: data.code, message: data.message };
   },
-  getPostDetail: async ({
-    token,
-    postId,
-  }: {
-    token?: string;
-    postId: string;
-  }) => {
+  getPostDetail: async ({ token, postId }) => {
     const params = { postId };
 
     const { status, data } = await apis['GET /post/:postId']({ token, params });

--- a/apps/client/src/feature/post/service/postService.ts
+++ b/apps/client/src/feature/post/service/postService.ts
@@ -18,6 +18,7 @@ export type PostService = {
     investmentMin,
     series,
     pathStatus,
+    token,
   }: {
     page?: number;
     roles?: string[];
@@ -25,6 +26,7 @@ export type PostService = {
     investmentMin?: number;
     series?: Series[];
     pathStatus?: number;
+    token: string | null;
   }): ServiceResponse<{
     posts: BriefPost[];
     paginator: Paginator;
@@ -88,6 +90,7 @@ export const implPostService = ({ apis }: { apis: Apis }): PostService => ({
     investmentMin,
     series,
     pathStatus,
+    token,
   }) => {
     const postPath = new URLSearchParams();
 
@@ -108,7 +111,7 @@ export const implPostService = ({ apis }: { apis: Apis }): PostService => ({
     const params = {
       postPath: postPath.toString(),
     };
-    const { status, data } = await apis['GET /post']({ params });
+    const { status, data } = await apis['GET /post']({ params, token: token !== null ? token: undefined});
 
     if (status === 200) {
       return {

--- a/apps/client/src/feature/post/ui/PostDetailView.tsx
+++ b/apps/client/src/feature/post/ui/PostDetailView.tsx
@@ -369,7 +369,10 @@ export const useGetPostDetail = ({ postId }: { postId: string }) => {
   const { data: postDetailData } = useQuery({
     queryKey: ['postServicce', 'getPostDetail', token] as const,
     queryFn: ({ queryKey: [, , t] }) => {
-      return postService.getPostDetail({ token: t !== null ? t: undefined, postId: postId });
+      return postService.getPostDetail({
+        token: t !== null ? t : undefined,
+        postId: postId,
+      });
     },
   });
 

--- a/apps/client/src/feature/post/ui/PostDetailView.tsx
+++ b/apps/client/src/feature/post/ui/PostDetailView.tsx
@@ -369,10 +369,7 @@ export const useGetPostDetail = ({ postId }: { postId: string }) => {
   const { data: postDetailData } = useQuery({
     queryKey: ['postServicce', 'getPostDetail', token] as const,
     queryFn: ({ queryKey: [, , t] }) => {
-      if (t === null) {
-        return postService.getPostDetail({ token: '', postId: postId });
-      }
-      return postService.getPostDetail({ token: t, postId: postId });
+      return postService.getPostDetail({ token: t !== null ? t: undefined, postId: postId });
     },
   });
 

--- a/apps/client/src/pages/LandingPage.tsx
+++ b/apps/client/src/pages/LandingPage.tsx
@@ -15,6 +15,7 @@ import {
 import { SkeletonPostCard } from '@/feature/landing/ui/SkeletonPostCard';
 import { useGuardContext } from '@/shared/context/hooks';
 import { ServiceContext } from '@/shared/context/ServiceContext';
+import { TokenContext } from '@/shared/context/TokenContext';
 import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
 
 export const LandingPage = () => {
@@ -143,6 +144,7 @@ export const useGetPosts = ({
   pathStatus?: number;
 }) => {
   const { postService } = useGuardContext(ServiceContext);
+  const { token } = useGuardContext(TokenContext);
 
   const { data: postsData } = useQuery({
     queryKey: [
@@ -163,6 +165,7 @@ export const useGetPosts = ({
         investmentMin,
         series,
         pathStatus,
+        token,
       });
       if (response.type === 'success') {
         return response.data;

--- a/packages/api/src/apis/localServer/apis.ts
+++ b/packages/api/src/apis/localServer/apis.ts
@@ -141,7 +141,7 @@ export const getLocalServerApis = ({
       token,
     }: {
       params: PostPathParams;
-      token: string | undefined;
+      token?: string;
     }) =>
       callWithOptionalToken<SuccessResponse<PostsResponse>>({
         method: "GET",

--- a/packages/api/src/apis/localServer/apis.ts
+++ b/packages/api/src/apis/localServer/apis.ts
@@ -136,10 +136,17 @@ export const getLocalServerApis = ({
         path: "user/me",
         token,
       }),
-    "GET /post": ({ params }: { params: PostPathParams }) =>
-      callWithoutToken<SuccessResponse<PostsResponse>>({
+    "GET /post": ({
+      params,
+      token,
+    }: {
+      params: PostPathParams;
+      token: string | undefined;
+    }) =>
+      callWithOptionalToken<SuccessResponse<PostsResponse>>({
         method: "GET",
         path: `post?${params.postPath}`,
+        token,
       }),
     "GET /post/:postId": ({
       token,


### PR DESCRIPTION
### 📝 작업 내용

- 전체 공고 및 상세 공고를 불러올 때 선택적으로 토큰을 사용하도록 설정합니다.
- landingpageLink에 빈 문자열이 들어오면 undefined로 요청을 보냅니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
