### PR TITLE
🐛 role 저장 시 decoded를 사용하지 않음

### DIFF
--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -37,6 +37,7 @@ import { RolesFilterContext } from '@/shared/context/RolesFilterContext';
 import { ServiceContext } from '@/shared/context/ServiceContext';
 import { TokenContext } from '@/shared/context/TokenContext';
 import { implFileService } from '@/shared/file/fileService';
+import { implRoleStateRepository } from '@/shared/role/state';
 import { implRolesFilterLocalStorageRepository } from '@/shared/rolesFilter/localstorage';
 import { implRolesFilterStateRepository } from '@/shared/rolesFilter/state';
 import { implTokenStateRepository } from '@/shared/token/state';
@@ -96,7 +97,8 @@ export const App = () => {
   );
 
   const ENV = useGuardContext(EnvContext);
-  const tokenStateRepository = implTokenStateRepository({ setToken, setRole });
+  const tokenStateRepository = implTokenStateRepository({ setToken });
+  const roleStateRepository = implRoleStateRepository({ setRole });
   const rolesFilterStateRepository = implRolesFilterStateRepository({
     setActiveCategory,
     setIsFilterDropdownOpen,
@@ -165,6 +167,7 @@ export const App = () => {
     authService: implAuthService({
       apis,
       tokenStateRepository,
+      roleStateRepository,
     }),
     postService: implPostService({ apis }),
     userService: implUserService({ apis }),

--- a/apps/client/src/feature/auth/service/authService.ts
+++ b/apps/client/src/feature/auth/service/authService.ts
@@ -2,6 +2,7 @@ import type { Apis } from '@waffle/api';
 
 import type { ServiceResponse } from '@/entities/response';
 import type { User } from '@/entities/user';
+import type { RoleStateRepository } from '@/shared/role/state';
 import type { TokenStateRepository } from '@/shared/token/state';
 
 export type AuthService = {
@@ -80,9 +81,11 @@ export type AuthService = {
 export const implAuthService = ({
   apis,
   tokenStateRepository,
+  roleStateRepository,
 }: {
   apis: Apis;
   tokenStateRepository: TokenStateRepository;
+  roleStateRepository: RoleStateRepository;
 }): AuthService => ({
   signUp: async ({ authType, info }) => {
     const body = { authType, info };
@@ -92,6 +95,7 @@ export const implAuthService = ({
       const token = data.token;
 
       tokenStateRepository.setToken({ token });
+      roleStateRepository.setRole({ role: data.user.userRole });
 
       return {
         type: 'success',
@@ -108,6 +112,7 @@ export const implAuthService = ({
       const token = data.token;
 
       tokenStateRepository.setToken({ token });
+      roleStateRepository.setRole({ role: data.user.userRole });
 
       return {
         type: 'success',
@@ -169,6 +174,7 @@ export const implAuthService = ({
       const accessToken = data.accessToken;
 
       tokenStateRepository.setToken({ token: accessToken });
+      roleStateRepository.setRoleByToken({ token: accessToken });
 
       return {
         type: 'success',
@@ -197,6 +203,8 @@ export const implAuthService = ({
     const { status, data } = await apis['POST /user/signout']({ token });
 
     tokenStateRepository.removeToken();
+    roleStateRepository.removeRole();
+
     if (status === 200) {
       return {
         type: 'success',

--- a/apps/client/src/shared/role/state.ts
+++ b/apps/client/src/shared/role/state.ts
@@ -1,0 +1,34 @@
+import { jwtDecode } from 'jwt-decode';
+
+import type { DecodedToken } from '@/entities/decodedToken';
+
+export type RoleStateRepository = {
+  setRole({ role }: { role: 'NORMAL' | 'CURATOR' | null }): void;
+  setRoleByToken({ token }: { token: string }): void;
+  removeRole(): void;
+};
+
+export const implRoleStateRepository = ({
+  setRole,
+}: {
+  setRole(role: 'NORMAL' | 'CURATOR' | null): void;
+}): RoleStateRepository => ({
+  setRole: ({ role }) => {
+    setRole(role);
+  },
+  setRoleByToken: ({ token }) => {
+    try {
+      const decoded = jwtDecode<DecodedToken>(token);
+      if (decoded.role === 'CURATOR' || decoded.role === 'NORMAL') {
+        setRole(decoded.role);
+        return;
+      }
+      setRole(null);
+    } catch {
+      setRole(null);
+    }
+  },
+  removeRole: () => {
+    setRole(null);
+  },
+});

--- a/apps/client/src/shared/token/state.ts
+++ b/apps/client/src/shared/token/state.ts
@@ -1,6 +1,3 @@
-import { jwtDecode } from 'jwt-decode';
-
-import type { DecodedToken } from '@/entities/decodedToken';
 export type TokenStateRepository = {
   setToken({ token }: { token: string }): void;
   removeToken(): void;
@@ -8,26 +5,13 @@ export type TokenStateRepository = {
 
 export const implTokenStateRepository = ({
   setToken,
-  setRole,
 }: {
   setToken(token: string | null): void;
-  setRole(role: 'NORMAL' | 'CURATOR' | null): void;
 }): TokenStateRepository => ({
   setToken: ({ token }) => {
     setToken(token);
-    try {
-      const decoded = jwtDecode<DecodedToken>(token);
-      if (decoded.role === 'CURATOR' || decoded.role === 'NORMAL') {
-        setRole(decoded.role);
-        return;
-      }
-      setRole(null);
-    } catch {
-      setRole(null);
-    }
   },
   removeToken: () => {
     setToken(null);
-    setRole(null);
   },
 });


### PR DESCRIPTION
### 📝 작업 내용

- role을 저장할 때 jwt를 decode하지 않습니다.
- jwt 연산으로 인한 렌더링 속도 저하를 방지할 수 있습니다.
