### PR TITLE
♻️ 상대경로 import를 허용하지 않는 eslint 룰 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,6 @@
 import react from '@woohm402/eslint-config-react';
 
 export default [
-  ...react({
-    tsconfigRootDir: import.meta.dirname,
-    envAllowedFiles: ['src/App.tsx'],
-  }),
   {
     ignores: [
       '.yarn',
@@ -13,5 +9,14 @@ export default [
       'dist',
       'src/components/ui/calendar.tsx',
     ],
+  },
+  ...react({
+    tsconfigRootDir: import.meta.dirname,
+    envAllowedFiles: ['src/App.tsx'],
+  }),
+  {
+    rules: {
+      'no-restricted-imports': ['error', { patterns: ['./*', '../*'] }],
+    },
   },
 ];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import './index.css';
+import '@/index.css';
 
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -10,6 +10,7 @@ import {
   type ExternalFileCallParams,
   implApi,
 } from '@/api';
+import { implExternalApi } from '@/api/client';
 import type { RolesFilterCategory } from '@/entities/filter';
 import { PATH } from '@/entities/route';
 import { implAuthService } from '@/feature/auth';
@@ -40,6 +41,7 @@ import { CompanyProtectedRoute } from '@/shared/auth/CompanyProtectedRoute';
 import { ReissueRoute } from '@/shared/auth/ReissueRoute';
 import { EnvContext } from '@/shared/context/EnvContext';
 import { useGuardContext } from '@/shared/context/hooks';
+import { RoleContext } from '@/shared/context/RoleContext';
 import { RolesFilterContext } from '@/shared/context/RolesFilterContext';
 import { ServiceContext } from '@/shared/context/ServiceContext';
 import { TokenContext } from '@/shared/context/TokenContext';
@@ -48,9 +50,6 @@ import { implRoleStateRepository } from '@/shared/role/state';
 import { implRolesFilterLocalStorageRepository } from '@/shared/rolesFilter/localstorage';
 import { implRolesFilterStateRepository } from '@/shared/rolesFilter/state';
 import { implTokenStateRepository } from '@/shared/token/state';
-
-import { implExternalApi } from './api/client';
-import { RoleContext } from './shared/context/RoleContext';
 
 const RouterProvider = () => {
   return (

--- a/src/api/apis/externalServer/apis.ts
+++ b/src/api/apis/externalServer/apis.ts
@@ -1,10 +1,10 @@
+import type { UploadFileRequest } from '@/api/apis/externalServer/schemas';
 import type {
   ErrorResponse,
   InternalFileCallParams,
   ResponseNecessary,
   SuccessResponse,
-} from '../../entities';
-import type { UploadFileRequest } from './schemas';
+} from '@/api/entities';
 
 type GetApisProps = {
   callWithFile: <R extends ResponseNecessary>(

--- a/src/api/apis/externalServer/index.ts
+++ b/src/api/apis/externalServer/index.ts
@@ -1,1 +1,1 @@
-export { getExternalServerApis } from './apis';
+export { getExternalServerApis } from '@/api/apis/externalServer/apis';

--- a/src/api/apis/index.ts
+++ b/src/api/apis/index.ts
@@ -1,2 +1,2 @@
-export { getExternalServerApis } from './externalServer';
-export { getLocalServerApis } from './localServer';
+export { getExternalServerApis } from '@/api/apis/externalServer';
+export { getLocalServerApis } from '@/api/apis//localServer';

--- a/src/api/apis/localServer/apis.ts
+++ b/src/api/apis/localServer/apis.ts
@@ -1,10 +1,4 @@
 import type {
-  ErrorResponse,
-  InternalCallParams,
-  ResponseNecessary,
-  SuccessResponse,
-} from '../../entities';
-import type {
   BookmarkPageParams,
   ChangePasswordRequest,
   CheckSnuMailVerificationRequest,
@@ -32,7 +26,13 @@ import type {
   TokenResponse,
   UserResponse,
   UserWithTokenResponse,
-} from './schemas';
+} from '@/api/apis/localServer/schemas';
+import type {
+  ErrorResponse,
+  InternalCallParams,
+  ResponseNecessary,
+  SuccessResponse,
+} from '@/api/entities';
 
 type GetApisProps = {
   callWithToken: <R extends ResponseNecessary>(

--- a/src/api/apis/localServer/index.ts
+++ b/src/api/apis/localServer/index.ts
@@ -1,1 +1,1 @@
-export { getLocalServerApis } from './apis';
+export { getLocalServerApis } from '@/api/apis/localServer/apis';

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-import { getExternalServerApis, getLocalServerApis } from './apis';
+import { getExternalServerApis, getLocalServerApis } from '@/api/apis';
 import type {
   ErrorResponse,
   ExternalCallParams,
@@ -6,7 +6,7 @@ import type {
   InternalCallParams,
   InternalFileCallParams,
   ResponseNecessary,
-} from './entities';
+} from '@/api/entities';
 
 type ImplApiProps = {
   externalCall(_: ExternalCallParams): Promise<ResponseNecessary>;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,6 @@
-export { implApi, type Apis, type ExternalApis } from './client';
-export type { ExternalCallParams, ExternalFileCallParams } from './entities';
-export type * as LocalServerDTO from './apis/localServer/schemas';
+export { implApi, type Apis, type ExternalApis } from '@/api/client';
+export type {
+  ExternalCallParams,
+  ExternalFileCallParams,
+} from '@/api/entities';
+export type * as LocalServerDTO from '@/api/apis/localServer/schemas';


### PR DESCRIPTION
### 📝 작업 내용

- 상대경로 import를 허용하지 않는 eslint 룰을 추가하였습니다.
- 현재 상대경로로 들어간 import 들을 모두 상대경로로 수정하였습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
