### PR TITLE
✨ 회사 커피챗 상세페이지 api 연결

### DIFF
--- a/src/feature/coffeeChat/ui/detail/ApplicantCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/ApplicantCoffeeChatDetailView.tsx
@@ -30,8 +30,8 @@ export const CoffeeChatDetailView = ({
 
   const handleCancel = () => {
     updateCoffeeChatStatus({
-      coffeeChatId: coffeeChatId,
-      body: { coffeeChatStatus: 'CANCELED' },
+      coffeeChatList: [coffeeChatId],
+      coffeeChatStatus: 'CANCELED',
     });
   };
 

--- a/src/feature/coffeeChat/ui/detail/ApplicantCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/ApplicantCoffeeChatDetailView.tsx
@@ -1,4 +1,3 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 
 import { CancelCoffeeChatCancelModal } from '@/components/modal/CancelCoffeeChatCancelModal';
@@ -6,10 +5,12 @@ import { FormErrorResponse } from '@/components/response/formResponse';
 import { TagStatus } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { SkeletonCoffeeChatDetailView } from '@/feature/coffeeChat/ui/detail/SkeletonCoffeeChatDetailView';
+import {
+  useGetCoffeeChatDetail,
+  useUpdateCoffeeChatStatus,
+} from '@/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks';
 import { EnvContext } from '@/shared/context/EnvContext';
 import { useGuardContext } from '@/shared/context/hooks';
-import { ServiceContext } from '@/shared/context/ServiceContext';
-import { TokenContext } from '@/shared/context/TokenContext';
 import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
 import { getFormatDate } from '@/util/postFormatFunctions';
 
@@ -23,13 +24,14 @@ export const CoffeeChatDetailView = ({
   const [responseMessage, setResponseMessage] = useState('');
   const { toMyPage } = useRouteNavigation();
   const [isCancel, setIsCancel] = useState(false);
-  const { cancelCoffeeChat, isPending } = useCancelCoffeeChat({
+  const { updateCoffeeChatStatus, isPending } = useUpdateCoffeeChatStatus({
     setResponseMessage,
   });
 
   const handleCancel = () => {
-    cancelCoffeeChat({
-      coffeeChatList: [coffeeChatId],
+    updateCoffeeChatStatus({
+      coffeeChatId: coffeeChatId,
+      body: { coffeeChatStatus: 'CANCELED' },
     });
   };
 
@@ -130,63 +132,4 @@ export const CoffeeChatDetailView = ({
       )}
     </>
   );
-};
-
-const useGetCoffeeChatDetail = ({ coffeeChatId }: { coffeeChatId: string }) => {
-  const { token } = useGuardContext(TokenContext);
-  const { coffeeChatService } = useGuardContext(ServiceContext);
-
-  const { data: coffeeChatDetailData } = useQuery({
-    queryKey: ['user', 'coffeeChat', coffeeChatId, token] as const,
-    queryFn: ({ queryKey: [, , , t] }) => {
-      if (t === null) {
-        throw new Error('토큰이 존재하지 않습니다.');
-      }
-      return coffeeChatService.getCoffeeChatDetail({
-        token: t,
-        coffeeChatId: coffeeChatId,
-      });
-    },
-    enabled: token !== null,
-  });
-
-  return { coffeeChatDetailData: coffeeChatDetailData };
-};
-
-const useCancelCoffeeChat = ({
-  setResponseMessage,
-}: {
-  setResponseMessage(input: string): void;
-}) => {
-  const { coffeeChatService } = useGuardContext(ServiceContext);
-  const { token } = useGuardContext(TokenContext);
-  const { toMyPage } = useRouteNavigation();
-  const queryClient = useQueryClient();
-
-  const { mutate: cancelCoffeeChat, isPending } = useMutation({
-    mutationFn: ({ coffeeChatList }: { coffeeChatList: string[] }) => {
-      if (token === null) {
-        throw new Error('토큰이 존재하지 않습니다.');
-      }
-      return coffeeChatService.cancelCoffeeChat({
-        token,
-        coffeeChatList,
-      });
-    },
-    onSuccess: async (response) => {
-      if (response.type === 'success') {
-        await queryClient.invalidateQueries();
-        toMyPage({ query: { tab: 'COFFEE_CHAT' } });
-      } else {
-        setResponseMessage(response.code);
-      }
-    },
-    onError: () => {
-      setResponseMessage('취소에 실패했습니다. 잠시 후에 다시 실행해주세요.');
-    },
-  });
-  return {
-    cancelCoffeeChat,
-    isPending,
-  };
 };

--- a/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
@@ -24,8 +24,8 @@ export const CoffeeChatDetailView = ({
 
   const handleStatusChange = (status: 'ACCEPTED' | 'REJECTED') => {
     updateCoffeeChatStatus({
-      coffeeChatId,
-      body: { coffeeChatStatus: status },
+      coffeeChatList: [coffeeChatId],
+      coffeeChatStatus: status,
     });
   };
 

--- a/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
@@ -1,15 +1,92 @@
-import { ApplicantInfo } from '@/feature/applicant';
+import { useState } from 'react';
 
-export const CoffeeChatDetailView = () => {
+import { FormErrorResponse } from '@/components/response/formResponse';
+import { Button } from '@/components/ui/button';
+import { ApplicantInfo } from '@/feature/applicant';
+import { SkeletonCoffeeChatDetailView } from '@/feature/coffeeChat/ui/detail/SkeletonCoffeeChatDetailView';
+import {
+  useGetCoffeeChatDetail,
+  useUpdateCoffeeChatStatus,
+} from '@/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks';
+import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
+
+export const CoffeeChatDetailView = ({
+  coffeeChatId,
+}: {
+  coffeeChatId: string;
+}) => {
+  const [responseMessage, setResponseMessage] = useState('');
+  const { coffeeChatDetailData } = useGetCoffeeChatDetail({ coffeeChatId });
+  const { toMyPage } = useRouteNavigation();
+  const { updateCoffeeChatStatus, isPending } = useUpdateCoffeeChatStatus({
+    setResponseMessage,
+  });
+
+  const handleStatusChange = (status: 'ACCEPTED' | 'REJECTED') => {
+    updateCoffeeChatStatus({
+      coffeeChatId,
+      body: { coffeeChatStatus: status },
+    });
+  };
+
+  if (coffeeChatDetailData === undefined) {
+    return <SkeletonCoffeeChatDetailView />;
+  }
+
+  if (coffeeChatDetailData.type === 'error') {
+    return (
+      <div>정보를 불러오는 중 문제가 발생하였습니다. 새로고침해주세요.</div>
+    );
+  }
+  const coffeeChatDetail = coffeeChatDetailData.data;
+  const isWaiting = coffeeChatDetail.coffeeChatStatus === 'WAITING';
+
   return (
-    <div className="mx-auto flex w-full flex-col gap-10 px-6 py-[30px] sm:w-screen-sm md:w-screen-md lg:w-screen-lg xl:max-w-screen-xl">
-      <div className="flex w-[700px] flex-col gap-6 rounded-lg bg-white px-[40px] py-[46px] text-grey-900">
-        <ApplicantInfo />
-        <div className="flex flex-col gap-[16px]">
-          <h3 className="text-22 font-bold">커피챗 내용</h3>
-          <p className="text-sm text-gray-700">커피챗 내용 test</p>
+    <>
+      <div className="mx-auto flex w-full gap-[90px] px-6 py-[30px] sm:w-screen-sm md:w-screen-md lg:w-screen-lg xl:max-w-screen-xl">
+        <div className="flex w-[700px] flex-col gap-6 rounded-lg bg-white px-[40px] py-[46px] text-grey-900">
+          <ApplicantInfo />
+          <div className="flex flex-col gap-[16px]">
+            <h3 className="text-22 font-bold">커피챗 신청 내용</h3>
+            <p className="text-sm text-gray-700">{coffeeChatDetail.content}</p>
+          </div>
+        </div>
+        <div className="mb-[86px] mt-[963px] flex flex-col gap-[8px]">
+          <Button
+            variant="default"
+            onClick={() => {
+              handleStatusChange('ACCEPTED');
+            }}
+            className="w-[292px]"
+            disabled={isPending || !isWaiting}
+          >
+            성사시키기
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              handleStatusChange('REJECTED');
+            }}
+            className="w-[292px]"
+            disabled={isPending || !isWaiting}
+          >
+            거절하기
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              toMyPage({ query: { tab: 'COFFEE_CHAT' } });
+            }}
+            className="w-[292px]"
+            disabled={isPending}
+          >
+            목록으로
+          </Button>
         </div>
       </div>
-    </div>
+      {responseMessage !== '' && (
+        <FormErrorResponse>{responseMessage}</FormErrorResponse>
+      )}
+    </>
   );
 };

--- a/src/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks.ts
+++ b/src/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks.ts
@@ -43,19 +43,21 @@ export const useUpdateCoffeeChatStatus = ({
 
   const { mutate: updateCoffeeChatStatus, isPending } = useMutation({
     mutationFn: ({
-      coffeeChatId,
-      body,
+      coffeeChatList,
+      coffeeChatStatus,
     }: {
-      coffeeChatId: string;
-      body: { coffeeChatStatus: CoffeeChatStatus };
+      coffeeChatList: string[];
+      coffeeChatStatus: CoffeeChatStatus;
     }) => {
       if (token === null) {
         throw new Error('토큰이 존재하지 않습니다.');
       }
       return coffeeChatService.updateCoffeeChatStatus({
         token,
-        coffeeChatId,
-        body,
+        body: {
+          coffeeChatStatus,
+          coffeeChatList,
+        },
       });
     },
     onSuccess: async (response) => {

--- a/src/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks.ts
+++ b/src/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { CoffeeChatStatus } from '@/api/apis/localServer/schemas';
+import { useGuardContext } from '@/shared/context/hooks';
+import { ServiceContext } from '@/shared/context/ServiceContext';
+import { TokenContext } from '@/shared/context/TokenContext';
+import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
+
+export const useGetCoffeeChatDetail = ({
+  coffeeChatId,
+}: {
+  coffeeChatId: string;
+}) => {
+  const { token } = useGuardContext(TokenContext);
+  const { coffeeChatService } = useGuardContext(ServiceContext);
+
+  const { data: coffeeChatDetailData } = useQuery({
+    queryKey: ['user', 'coffeeChat', coffeeChatId, token] as const,
+    queryFn: ({ queryKey: [, , , t] }) => {
+      if (t === null) {
+        throw new Error('토큰이 존재하지 않습니다.');
+      }
+      return coffeeChatService.getCoffeeChatDetail({
+        token: t,
+        coffeeChatId: coffeeChatId,
+      });
+    },
+    enabled: token !== null,
+  });
+
+  return { coffeeChatDetailData: coffeeChatDetailData };
+};
+
+export const useUpdateCoffeeChatStatus = ({
+  setResponseMessage,
+}: {
+  setResponseMessage(input: string): void;
+}) => {
+  const { coffeeChatService } = useGuardContext(ServiceContext);
+  const { token } = useGuardContext(TokenContext);
+  const { toMyPage } = useRouteNavigation();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateCoffeeChatStatus, isPending } = useMutation({
+    mutationFn: ({
+      coffeeChatId,
+      body,
+    }: {
+      coffeeChatId: string;
+      body: { coffeeChatStatus: CoffeeChatStatus };
+    }) => {
+      if (token === null) {
+        throw new Error('토큰이 존재하지 않습니다.');
+      }
+      return coffeeChatService.updateCoffeeChatStatus({
+        token,
+        coffeeChatId,
+        body,
+      });
+    },
+    onSuccess: async (response) => {
+      if (response.type === 'success') {
+        await queryClient.invalidateQueries();
+        toMyPage({ query: { tab: 'COFFEE_CHAT' } });
+      } else {
+        setResponseMessage(response.code);
+      }
+    },
+    onError: () => {
+      setResponseMessage('취소에 실패했습니다. 잠시 후에 다시 실행해주세요.');
+    },
+  });
+  return {
+    updateCoffeeChatStatus,
+    isPending,
+  };
+};

--- a/src/pages/CompanyCoffeeChatDetailPage.tsx
+++ b/src/pages/CompanyCoffeeChatDetailPage.tsx
@@ -14,8 +14,7 @@ export const CompanyCoffeeChatDetailPage = () => {
   return (
     <div className="min-h-screen bg-grey-50">
       <GlobalNavigationBar />
-      {/* TODO: coffee chat id를 넘기기  */}
-      <CompanyCoffeeChatDetailView />
+      <CompanyCoffeeChatDetailView coffeeChatId={coffeeChatId} />
     </div>
   );
 };


### PR DESCRIPTION
### 📝 작업 내용

- 회사 커피챗 상세 페이지 api 연결
- 기존 cancel coffee chat service를 제거하고 update coffeechat status로 거절, 성사, 취소 등 모두 관리하도록 수정함
- 회사, 구직자 detail view에서 공용으로 사용하는 hook을 따로 별도 파일로 뽑아서 정리함 (우선 같은 계층에 hook 파일에 넣어 관리중)

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
