### PR TITLE
커피챗 신청 유무에 따른 커피챗 버튼 활성/비활성화 기능 구현 및 기타 수정

### DIFF
--- a/src/api/apis/localServer/apis.ts
+++ b/src/api/apis/localServer/apis.ts
@@ -197,6 +197,19 @@ export const getLocalServerApis = ({
         token,
         body,
       }),
+    'GET /coffeeChat/:postId/status': ({
+      token,
+      params,
+    }: {
+      token: string;
+      params: PostIdParams;
+    }) => {
+      return callWithToken<SuccessResponse<{ isSubmitted: boolean }>>({
+        method: 'GET',
+        path: `coffeeChat/${params.postId}/status`,
+        token,
+      });
+    },
     'GET /coffeeChat/:coffeeChatId': ({
       token,
       params,

--- a/src/api/apis/localServer/schemas.ts
+++ b/src/api/apis/localServer/schemas.ts
@@ -111,7 +111,7 @@ export type CoffeeChatApplicant = {
   content: string;
 };
 
-type Applicant = {
+export type Applicant = {
   id: string;
   name: string;
   createdAt: string;
@@ -130,7 +130,7 @@ type Applicant = {
   links?: Link[];
 };
 
-type CoffeeChatCompany = {
+export type CoffeeChatCompany = {
   id: string;
   postId: string;
   title: string;

--- a/src/entities/coffeeChat.ts
+++ b/src/entities/coffeeChat.ts
@@ -1,37 +1,4 @@
-import type { Applicant } from '@/mocks/applicant/schemas';
-
 export type CoffeeChatStatus = 'WAITING' | 'ACCEPTED' | 'CANCELED' | 'REJECTED';
-
-export type CoffeeChat = {
-  id: string;
-  postId: string;
-  title: string;
-  company: {
-    name: string;
-    imageKey?: string;
-  };
-  createdAt: string;
-  updatedAt: string;
-  coffeeChatStatus: CoffeeChatStatus;
-  changed: boolean;
-  content: string;
-};
-
-export type CompanyCoffeeChat = {
-  id: string;
-  postId: string;
-  title: string;
-  company: {
-    companyName: string;
-    companyImageKey?: string;
-  };
-  createdAt: string;
-  updatedAt: string;
-  coffeeChatStatus: CoffeeChatStatus;
-  changed: boolean;
-  content: string;
-  applicant: Applicant;
-};
 
 export type CoffeeChatRequest = {
   phoneNumber: string;

--- a/src/entities/coffeeChat.ts
+++ b/src/entities/coffeeChat.ts
@@ -1,3 +1,5 @@
+import type { Applicant } from '@/mocks/applicant/schemas';
+
 export type CoffeeChatStatus = 'WAITING' | 'ACCEPTED' | 'CANCELED' | 'REJECTED';
 
 export type CoffeeChat = {
@@ -13,6 +15,22 @@ export type CoffeeChat = {
   coffeeChatStatus: CoffeeChatStatus;
   changed: boolean;
   content: string;
+};
+
+export type CompanyCoffeeChat = {
+  id: string;
+  postId: string;
+  title: string;
+  company: {
+    companyName: string;
+    companyImageKey?: string;
+  };
+  createdAt: string;
+  updatedAt: string;
+  coffeeChatStatus: CoffeeChatStatus;
+  changed: boolean;
+  content: string;
+  applicant: Applicant;
 };
 
 export type CoffeeChatRequest = {

--- a/src/feature/applicant/ui/mypage/ApplicantInfo.tsx
+++ b/src/feature/applicant/ui/mypage/ApplicantInfo.tsx
@@ -3,29 +3,55 @@ import { useQuery } from '@tanstack/react-query';
 import { DownloadButtonWithPresignedUrl } from '@/components/button/DownloadButtonWithPresignedUrl';
 import { LinkButton } from '@/components/button/LinkButton';
 import { ThumbnailWithPresignedUrl } from '@/components/thumbnail/ThumbnailWithPresignedUrl';
-import { Badge } from '@/components/ui/badge';
+import { Badge, TagStatus } from '@/components/ui/badge';
 import { SeperatorLine } from '@/components/ui/separator';
+import type { CoffeeChatStatus } from '@/entities/coffeeChat';
 import { NoApplicantInfo } from '@/feature/applicant/ui/mypage/NoApplicantInfo';
 import { SkeletonApplicantInfo } from '@/feature/applicant/ui/mypage/SkeletonApplicantInfo';
+import type { Applicant } from '@/mocks/applicant/schemas';
 import { useGuardContext } from '@/shared/context/hooks';
 import { ServiceContext } from '@/shared/context/ServiceContext';
 import { TokenContext } from '@/shared/context/TokenContext';
 import { formatMinorJobToLabel } from '@/util/format';
+import { getShortenedDate } from '@/util/postFormatFunctions';
 
-export const ApplicantInfo = () => {
-  const { applicantInfoData } = useApplicantInfo();
+export type ApplicantInfoProps = {
+  applicantData?: Applicant;
+  coffeeChatStatus?: CoffeeChatStatus;
+  fetchOwnInfo?: boolean;
+  // 생성 날짜 추가
+  createdAt?: string;
+};
 
-  if (applicantInfoData === undefined) {
+export const ApplicantInfo = ({
+  applicantData,
+  coffeeChatStatus,
+  fetchOwnInfo = true,
+  createdAt,
+}: ApplicantInfoProps) => {
+  const { applicantInfoData } = useApplicantInfo(fetchOwnInfo);
+
+  if (fetchOwnInfo && applicantInfoData === undefined) {
     return <SkeletonApplicantInfo />;
   }
 
-  if (applicantInfoData.type === 'error') {
+  if (fetchOwnInfo && applicantInfoData?.type === 'error') {
     if (applicantInfoData.code === 'APPLICANT_002') {
       return <NoApplicantInfo />;
     }
     return (
       <p>프로필 정보를 불러오는 데 실패했습니다. 잠시 후 새로고침해주세요.</p>
     );
+  }
+
+  const userData = fetchOwnInfo
+    ? applicantInfoData?.type === 'success'
+      ? applicantInfoData.data
+      : undefined
+    : applicantData;
+
+  if (userData == null) {
+    return <SkeletonApplicantInfo />;
   }
 
   const {
@@ -41,29 +67,48 @@ export const ApplicantInfo = () => {
     cvKey,
     portfolioKey,
     links,
-  } = applicantInfoData.data;
+  } = userData;
 
   const formattedPositions = positions?.map((position) =>
     formatMinorJobToLabel(position),
   );
 
   return (
-    <div className="flex w-[700px] flex-col gap-6 rounded-lg bg-white px-[24px] py-[48px] text-grey-900">
+    <div className="flex flex-col gap-[24px]">
       <section className="flex gap-4">
-        {imageKey !== undefined ? (
-          <ThumbnailWithPresignedUrl s3Key={imageKey} type="USER_THUMBNAIL" />
-        ) : (
-          <div className="h-[80px] w-[80px] bg-grey-200"></div>
-        )}
-        <div className="flex flex-col gap-3">
-          <p className="text-30 font-bold">{name}</p>
-          <span className="font-regular">{`${department} ${enrollYear}학번`}</span>
+        <div className="flex w-full justify-between">
+          <div className="flex gap-[16px]">
+            {imageKey !== undefined ? (
+              <ThumbnailWithPresignedUrl
+                s3Key={imageKey}
+                type="USER_THUMBNAIL"
+              />
+            ) : (
+              <div className="h-[80px] w-[80px] bg-grey-200"></div>
+            )}
+            <div className="flex flex-col gap-3">
+              <p className="text-30 font-bold">{name}</p>
+              <span className="font-regular">{`${department} ${enrollYear}학번`}</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {createdAt != null && (
+              <span className="text-sm text-grey-300">
+                {getShortenedDate(createdAt)}
+              </span>
+            )}
+            {coffeeChatStatus !== undefined && (
+              <TagStatus coffeeChatStatus={coffeeChatStatus} />
+            )}
+          </div>
         </div>
       </section>
 
-      <section>
-        <p>{slogan}</p>
-      </section>
+      {slogan != null && (
+        <section>
+          <p>{slogan}</p>
+        </section>
+      )}
 
       <SeperatorLine />
 
@@ -90,7 +135,7 @@ export const ApplicantInfo = () => {
         <section className="flex flex-col gap-4">
           <h3 className="text-22 font-bold">자기소개</h3>
           <p>{explanation}</p>
-          <div className="pag-4 flex">
+          <div className="flex gap-4">
             {cvKey !== undefined && (
               <DownloadButtonWithPresignedUrl s3Key={cvKey} type="CV">
                 이력서 다운로드
@@ -132,7 +177,7 @@ export const ApplicantInfo = () => {
   );
 };
 
-const useApplicantInfo = () => {
+const useApplicantInfo = (enabled = true) => {
   const { token } = useGuardContext(TokenContext);
   const { applicantService } = useGuardContext(ServiceContext);
   const { data: applicantInfoData } = useQuery({
@@ -143,7 +188,7 @@ const useApplicantInfo = () => {
       }
       return applicantService.getProfile({ token: t });
     },
-    enabled: token !== null,
+    enabled: enabled && token !== null,
   });
 
   return { applicantInfoData };

--- a/src/feature/coffeeChat/service/coffeeChatService.ts
+++ b/src/feature/coffeeChat/service/coffeeChatService.ts
@@ -11,6 +11,13 @@ import type { CoffeeChatRequest } from '@/entities/coffeeChat';
 import type { ServiceResponse } from '@/entities/response';
 
 export type CoffeeChatService = {
+  getCoffeeChatStatus: ({
+    token,
+    postId,
+  }: {
+    token: string;
+    postId: string;
+  }) => ServiceResponse<{ isSubmitted: boolean }>;
   getCoffeeChatDetail: ({
     token,
     coffeeChatId,
@@ -58,6 +65,36 @@ export const implCoffeeChatService = ({
 }: {
   apis: Apis;
 }): CoffeeChatService => ({
+  getCoffeeChatStatus: async ({
+    token,
+    postId,
+  }: {
+    token: string;
+    postId: string;
+  }) => {
+    const params = { postId };
+
+    try {
+      const { status, data } = await apis['GET /coffeeChat/:postId/status']({
+        token,
+        params,
+      });
+
+      if (status === 200) {
+        return {
+          type: 'success',
+          data,
+        };
+      }
+      return { type: 'error', code: data.code, message: data.message };
+    } catch (_) {
+      return {
+        type: 'error',
+        code: 'UNKNOWN_ERROR',
+        message: 'Failed to fetch coffee chat status',
+      };
+    }
+  },
   getCoffeeChatDetail: async ({
     token,
     coffeeChatId,

--- a/src/feature/coffeeChat/service/coffeeChatService.ts
+++ b/src/feature/coffeeChat/service/coffeeChatService.ts
@@ -1,12 +1,13 @@
 import type { Apis } from '@/api';
 import type {
   CoffeeChatApplicant,
+  CoffeeChatCompany,
   CoffeeChatCount,
   CoffeeChatDetailList,
   CoffeeChatListResponse,
   CoffeeChatStatus,
 } from '@/api/apis/localServer/schemas';
-import type { CoffeeChat, CoffeeChatRequest } from '@/entities/coffeeChat';
+import type { CoffeeChatRequest } from '@/entities/coffeeChat';
 import type { ServiceResponse } from '@/entities/response';
 
 export type CoffeeChatService = {
@@ -16,7 +17,7 @@ export type CoffeeChatService = {
   }: {
     token: string;
     coffeeChatId: string;
-  }) => ServiceResponse<CoffeeChat>;
+  }) => ServiceResponse<CoffeeChatApplicant | CoffeeChatCompany>;
   getCoffeeChatList: ({
     token,
   }: {

--- a/src/feature/coffeeChat/ui/detail/ApplicantCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/ApplicantCoffeeChatDetailView.tsx
@@ -9,6 +9,7 @@ import {
   useGetCoffeeChatDetail,
   useUpdateCoffeeChatStatus,
 } from '@/feature/coffeeChat/ui/detail/useCoffeeChatDetailHooks';
+import type { CoffeeChatApplicant } from '@/mocks/coffeeChat/schemas';
 import { EnvContext } from '@/shared/context/EnvContext';
 import { useGuardContext } from '@/shared/context/hooks';
 import { useRouteNavigation } from '@/shared/route/useRouteNavigation';
@@ -44,7 +45,7 @@ export const CoffeeChatDetailView = ({
       <div>정보를 불러오는 중 문제가 발생하였습니다. 새로고침해주세요.</div>
     );
   }
-  const coffeeChatDetail = coffeeChatDetailData.data;
+  const coffeeChatDetail = coffeeChatDetailData.data as CoffeeChatApplicant;
   return (
     <>
       <div className="flex w-full bg-gray-50 py-10">

--- a/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import type { CoffeeChatCompany } from '@/api/apis/localServer/schemas';
 import { FormErrorResponse } from '@/components/response/formResponse';
 import { Button } from '@/components/ui/button';
 import { ApplicantInfo } from '@/feature/applicant';
@@ -38,14 +39,19 @@ export const CoffeeChatDetailView = ({
       <div>정보를 불러오는 중 문제가 발생하였습니다. 새로고침해주세요.</div>
     );
   }
-  const coffeeChatDetail = coffeeChatDetailData.data;
+  const coffeeChatDetail = coffeeChatDetailData.data as CoffeeChatCompany;
   const isWaiting = coffeeChatDetail.coffeeChatStatus === 'WAITING';
 
   return (
-    <>
+    <div>
       <div className="mx-auto flex w-full gap-[90px] px-6 py-[30px] sm:w-screen-sm md:w-screen-md lg:w-screen-lg xl:max-w-screen-xl">
         <div className="flex w-[700px] flex-col gap-6 rounded-lg bg-white px-[40px] py-[46px] text-grey-900">
-          <ApplicantInfo />
+          <ApplicantInfo
+            fetchOwnInfo={false}
+            applicantData={coffeeChatDetail.applicant}
+            coffeeChatStatus={coffeeChatDetail.coffeeChatStatus}
+            createdAt={coffeeChatDetail.createdAt}
+          />
           <div className="flex flex-col gap-[16px]">
             <h3 className="text-22 font-bold">커피챗 신청 내용</h3>
             <p className="text-sm text-gray-700">{coffeeChatDetail.content}</p>
@@ -87,6 +93,6 @@ export const CoffeeChatDetailView = ({
       {responseMessage !== '' && (
         <FormErrorResponse>{responseMessage}</FormErrorResponse>
       )}
-    </>
+    </div>
   );
 };

--- a/src/mocks/applicant/schemas.ts
+++ b/src/mocks/applicant/schemas.ts
@@ -15,9 +15,9 @@ export type Applicant = {
   positions?: string[];
   slogan?: string;
   explanation?: string;
-  stack?: string[];
+  stacks?: string[];
   imageKey?: string;
   cvKey?: string;
   portfolioKey?: string;
-  linkes?: Link[];
+  links?: Link[];
 };

--- a/src/pages/ApplicantMyPage.tsx
+++ b/src/pages/ApplicantMyPage.tsx
@@ -37,7 +37,9 @@ export const ApplicantMyPage = () => {
               <BookmarkListView />
             </TabsContent>
             <TabsContent value="PROFILE">
-              <ApplicantInfo />
+              <div className="w-[700px] gap-6 rounded-lg bg-white px-[24px] py-[48px] text-grey-900">
+                <ApplicantInfo fetchOwnInfo={true} />
+              </div>
             </TabsContent>
           </div>
         </Tabs>


### PR DESCRIPTION
### 📝 작업 내용

- 커피챗 신청 유무에 따라 커피챗 버튼 활성/비활성화 기능 구현
- 기존 회사 커피챗 상세 페이지에서 유저 정보를 잘못 가져오던 것을 수정

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
