### PR TITLE
💄 카드 컴포넌트 피그마와 동일하게 수정

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from '@/lib/utils';
 
 const badgeClassName = cva(
-  'inline-flex items-center rounded-md px-2 py-1.5 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-md px-2 py-1.5 text-13 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/feature/post/ui/common/PostCard.tsx
+++ b/src/feature/post/ui/common/PostCard.tsx
@@ -101,7 +101,7 @@ export const PostCard = ({
           </div>
         </div>
 
-        <div className="w-full flex-1 text-13 font-regular leading-[1.5] text-grey-700">
+        <div className="line-clamp-3 w-full flex-1 truncate text-wrap text-13 font-regular leading-[1.5] text-grey-700">
           {slogan}
         </div>
 

--- a/src/feature/post/ui/common/PostCard.tsx
+++ b/src/feature/post/ui/common/PostCard.tsx
@@ -59,28 +59,28 @@ export const PostCard = ({
 
   return (
     <div
-      className="cursor-pointer rounded-lg bg-white transition-shadow hover:shadow-md"
+      className="flex h-[270px] cursor-pointer flex-col rounded-lg bg-white transition-shadow hover:shadow-md"
       onClick={() => {
         onDetailClick(id);
       }}
     >
       {/* 직군 & 마감일 */}
       <div className="relative flex h-[50px] items-center justify-between rounded-t-lg bg-grey-200 px-[22px]">
-        <div className="flex items-center gap-2">
-          <img src={ICON_SRC.PERSON} className="h-6 w-6" />
-          <span className="text-15 font-semibold text-grey-900">
+        <div className="flex max-w-[80%] items-center gap-2">
+          <img src={ICON_SRC.PERSON} className="h-6 w-6 flex-shrink-0" />
+          <span className="truncate text-15 font-semibold text-grey-900">
             {positionTitle}
           </span>
         </div>
 
-        <span className="text-grey-400">
+        <span className="flex-shrink-0 text-grey-400">
           {formatEmploymentState({ isActive, employmentEndDate })}
         </span>
         {/* 삼각형 */}
-        <div className="absolute bottom-[-10px] right-6 h-0 w-0 border-l-[10px] border-r-[10px] border-t-[10px] border-l-transparent border-r-transparent border-t-grey-200 text-lg"></div>
+        <div className="absolute bottom-[-9px] right-6 h-0 w-0 border-l-[10px] border-r-[10px] border-t-[10px] border-l-transparent border-r-transparent border-t-grey-200 text-lg"></div>
       </div>
 
-      <section className="flex flex-col gap-4 px-[22px] py-[18px]">
+      <section className="flex flex-1 flex-col gap-4 px-[22px] py-[18px]">
         {/* 회사 정보 */}
         <div className="flex items-center gap-[14px]">
           {/* 회사 이미지 */}
@@ -95,16 +95,18 @@ export const PostCard = ({
             <h3 className="text-18 font-semibold text-grey-900">
               {companyName}
             </h3>
-            <span className="text-12 text-grey-800">
+            <span className="text-12 font-regular text-grey-800">
               {formatDomainToLabel(domain)}
             </span>
           </div>
         </div>
 
-        <div className="min-h-[62px] w-full text-grey-700">{slogan}</div>
+        <div className="w-full flex-1 text-13 font-regular leading-[1.5] text-grey-700">
+          {slogan}
+        </div>
 
         {/* 회사 위치 및 태그 */}
-        <div className="flex w-full justify-between gap-3 py-1">
+        <div className="flex w-full flex-wrap items-center justify-between gap-3 overflow-hidden py-1">
           <div className="flex items-center gap-2">
             <Badge variant="secondary">
               <img src={ICON_SRC.LOCATION} />{' '}

--- a/src/feature/post/ui/landing/LandingPostView.tsx
+++ b/src/feature/post/ui/landing/LandingPostView.tsx
@@ -63,7 +63,7 @@ export const LandingPostView = ({
       {' '}
       {/* 게시글 리스트 */}
       <main>
-        <div className="grid w-full grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
           <PostCardView />
         </div>
       </main>


### PR DESCRIPTION
### 📝 작업 내용

- 공고가 너무 길어질 경우 ...으로 줄여줍니다.
- 하단 컴포넌트 위치가 동일하도록 맞춰둡니다.
- 기타 gap, 폰트 크기를 맞추었습니다.

### 확인 사항
현재 피그마는 1920 기준으로 작성되어 있으며, 카드컴포넌트의 기본 너비가 380px이지만, 현재 홈페이지에선, 너비가 330px로 설정되어 있습니다. 현재 제 노트북도 가로가 1920 픽셀이 안되는 것 같은데, 만약 그렇다면 디자이너님께 카드 컴포넌트 폭을 바꿔달라고 부탁드려야 할 것 같습니다.

### 📸 스크린샷 (선택)
- 카드 컴포넌트 수정본
![image](https://github.com/user-attachments/assets/da45f2bd-2dd7-45ff-b3b0-200c1a75cbc3)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
