### PR TITLE
🐛 프로필 보기 및 생성 시 빈 리스트 및 리스트 내부 빈 문자열 대응

### DIFF
--- a/src/feature/applicant/presentation/applicantFormPresentation.ts
+++ b/src/feature/applicant/presentation/applicantFormPresentation.ts
@@ -115,6 +115,12 @@ export const applicantFormPresentation: ApplicantFormPresentation = {
       initialState: initialStateForInput,
     });
 
+    const filteredMinors = minorDepartment.value.filter(
+      (item) => item.trim().length !== 0,
+    );
+    const filteredPositions = positions.value.filter(
+      (item) => item.trim().length !== 0,
+    );
     const filteredLinks = links.value.filter(
       (item) =>
         item.link.trim().length !== 0 && item.description.trim().length !== 0,
@@ -151,11 +157,11 @@ export const applicantFormPresentation: ApplicantFormPresentation = {
             majorDepartment.isError ||
             majorDepartment.value.trim().length === 0 ||
             minorDepartment.isError,
-          value: [majorDepartment.value, ...minorDepartment.value].join(','),
+          value: [majorDepartment.value, ...filteredMinors].join(','),
         },
         positions: {
           isError: positions.isError,
-          value: positions.value.length !== 0 ? positions.value : undefined,
+          value: filteredPositions.length !== 0 ? filteredPositions : undefined,
         },
         slogan: {
           isError: slogan.isError,

--- a/src/feature/applicant/ui/mypage/ApplicantProfileInfo.tsx
+++ b/src/feature/applicant/ui/mypage/ApplicantProfileInfo.tsx
@@ -78,7 +78,7 @@ export const ApplicantProfileInfo = ({
         </div>
       </section>
 
-      {slogan != null && (
+      {slogan !== undefined && (
         <section>
           <p>{slogan}</p>
         </section>

--- a/src/feature/company/ui/mypage/CompanyProfileInfo.tsx
+++ b/src/feature/company/ui/mypage/CompanyProfileInfo.tsx
@@ -111,7 +111,7 @@ export const CompanyProfileInfo = ({
             )}
           </div>
         )}
-        {links !== undefined && (
+        {links !== undefined && links.length !== 0 && (
           <div className="flex flex-col gap-3">
             <p className="text-16 font-bold text-grey-800">외부 링크</p>
             <div className="flex flex-col gap-[10px]">
@@ -127,7 +127,7 @@ export const CompanyProfileInfo = ({
             </div>
           </div>
         )}
-        {tags !== undefined && (
+        {tags !== undefined && tags.length !== 0 && (
           <div className="flex flex-col gap-3">
             <p className="text-16 font-bold text-grey-800">태그</p>
             <div className="flex gap-[6px]">
@@ -140,7 +140,7 @@ export const CompanyProfileInfo = ({
           </div>
         )}
         <div className="flex flex-col gap-3">
-          <p className="text-16 font-bold text-grey-800">상세 소개</p>
+          <p className="text-16 font-bold text-grey-800">회사 상세 소개</p>
           <MarkdownPreview content={detail} />
         </div>
         {vcName !== undefined && vcRecommendation !== undefined && (


### PR DESCRIPTION
### 📝 작업 내용

- 유저 프로필 생성 시 리스트 내부의 빈 문자열을 제거하고 생성하도록 하였습니다.
- 회사 프로필 보기 시 빈 리스트에 대응하도록 설정하였습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
