### PR TITLE
💄 커피챗 상세 보기 최대 폭 너비 조정 및 내가 작성한 공고에서 두 줄로만 나타나도록 설정

### DIFF
--- a/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
+++ b/src/feature/coffeeChat/ui/detail/CompanyCoffeeChatDetailView.tsx
@@ -46,8 +46,8 @@ export const CoffeeChatDetailView = ({
 
   return (
     <div>
-      <div className="mx-auto flex w-full px-6 py-[30px] sm:w-screen-sm md:w-screen-md lg:w-screen-lg xl:max-w-screen-xl">
-        <div className="flex w-full flex-col gap-6 gap-[28px] rounded-lg bg-white px-[40px] py-[46px] text-grey-900">
+      <div className="mx-auto flex w-full max-w-[700px] px-6 py-[30px]">
+        <div className="flex w-full flex-col gap-[28px] rounded-lg bg-white px-[40px] py-[46px] text-grey-900">
           <div className="flex items-center justify-between">
             <h1 className="text-30 font-bold">커피챗 신청서</h1>
             <div className="flex items-center gap-2">

--- a/src/feature/post/ui/mypage/company/MyPostList.tsx
+++ b/src/feature/post/ui/mypage/company/MyPostList.tsx
@@ -58,7 +58,7 @@ export const MyPostList = ({
     <div className="order-2 flex w-full flex-1 flex-col gap-6 lg:order-none">
       {/* 회사 소개 카드 */}
       <div className="m-autogap-2 flex w-full flex-col md:flex-row">
-        <div className="grid w-full grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid w-full grid-cols-1 gap-6 md:grid-cols-2">
           {postsData.data.posts.map((item, idx) => (
             <CompanyPostCard
               key={`post-${idx}`}


### PR DESCRIPTION
### 📝 작업 내용

- 커피챗 상세 보기의 최대 폭을 700px로 고정하였습니다.
- 내가 작성한 공고를 두 줄로만 나타나도록 설정합니다.

### 📸 스크린샷 (선택)
- 커피챗 상세 보기
![image](https://github.com/user-attachments/assets/785aeaf3-b562-48dc-9396-172f42bf7a73)

- 커피챗 상세보기 스켈레톤 ui
![image](https://github.com/user-attachments/assets/3913964f-8d48-482c-82b8-de7a7e8dd057)

- 내가 작성한 공고
![image](https://github.com/user-attachments/assets/be8e2714-370d-465b-b9ad-a1311bb41f9f)


### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
