### PR TITLE
💄 커피챗 목록 페이지 반응형 적용

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -36,7 +36,7 @@ function Badge({ className, variant, ...props }: BadgeProps) {
 }
 
 const tagStatusClassName = cva(
-  'text inline-flex items-center rounded-sm border-transparent px-2 py-1.5 text-13 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'text inline-flex items-center whitespace-nowrap rounded-sm border-transparent px-2 py-1.5 text-13 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/feature/coffeeChat/ui/mypage/applicant/ApplicantCoffeeChatListView.tsx
+++ b/src/feature/coffeeChat/ui/mypage/applicant/ApplicantCoffeeChatListView.tsx
@@ -26,12 +26,12 @@ export const ApplicantCoffeeChatListView = () => {
   }
 
   return (
-    <div className="flex w-full flex-col gap-3 text-grey-900">
+    <div className="flex w-full flex-col gap-3 overflow-x-auto text-grey-900">
       {coffeeChatListData !== undefined ? (
         coffeeChatListData.data.coffeeChatList.map((coffeeChat) => (
           <div
             key={coffeeChat.id}
-            className="relative flex h-[50px] cursor-pointer items-center justify-between rounded-xl bg-white px-6 duration-300 hover:shadow-md"
+            className="relative flex h-[50px] min-w-80 cursor-pointer items-center justify-between rounded-xl bg-white px-6 duration-300 hover:shadow-md"
             onClick={() => {
               toCoffeeChatDetail({ coffeeChatId: coffeeChat.id });
             }}

--- a/src/feature/coffeeChat/ui/mypage/company/CompanyCoffeeChatListView.tsx
+++ b/src/feature/coffeeChat/ui/mypage/company/CompanyCoffeeChatListView.tsx
@@ -43,10 +43,10 @@ export const CompanyCoffeeChatListView = ({
   }
 
   return (
-    <div className="flex w-full flex-col gap-3">
+    <div className="flex w-full flex-col gap-3 overflow-x-auto">
       {coffeeChatListData !== undefined ? (
         coffeeChatListData.data.coffeeChatList.map((coffeeChat) => (
-          <div key={coffeeChat.id} className="flex items-center gap-4">
+          <div key={coffeeChat.id} className="flex min-w-96 items-center gap-4">
             {isSelectMode && (
               <div className="flex w-[20px] items-center justify-center">
                 {coffeeChat.coffeeChatStatus === 'WAITING' && (
@@ -61,7 +61,7 @@ export const CompanyCoffeeChatListView = ({
             )}
             <div
               key={coffeeChat.id}
-              className="relative flex h-[50px] flex-1 cursor-pointer items-center justify-between rounded-xl bg-white px-4 px-6 duration-300 hover:shadow-md"
+              className="relative ml-2 flex h-[50px] flex-1 cursor-pointer items-center justify-between rounded-xl bg-white px-6 duration-300 hover:shadow-md"
               onClick={() => {
                 toCoffeeChatDetail({ coffeeChatId: coffeeChat.id });
               }}


### PR DESCRIPTION
### 📝 작업 내용

- 구직자, 회사 커피챗 리스트가 width가 엄청 작을 때 (320px 정도) 깨져서 리스트에 가로 scroll bar를 넣었습니다.

### 📸 스크린샷 (선택)
<img width="421" alt="Screenshot 2025-05-04 at 2 25 38 AM" src="https://github.com/user-attachments/assets/86abbbbf-21c6-4721-a867-6748003fbe35" />


### 🚀 리뷰 요구사항 (선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
